### PR TITLE
🔧 Refactor : # 360  rAF-throttle 적용

### DIFF
--- a/src/hooks/useNavVisibility.ts
+++ b/src/hooks/useNavVisibility.ts
@@ -6,19 +6,30 @@ export function useNavVisibility() {
   const [isVisible, setIsVisible] = useState(false);
 
   const compute = useCallback((scrollTop: number) => {
-    setIsVisible(scrollTop > 8);
+    const nextVisible = scrollTop > 8;
+    setIsVisible(nextVisible);
   }, []);
 
   useEffect(() => {
     const el = document.getElementById('app-scroll');
     if (!el) return;
 
-    const onScroll = () => compute(el.scrollTop);
+    let rafId = 0;
+    const scheduleCompute = () => {
+      if (rafId) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = 0;
+        compute(el.scrollTop);
+      });
+    };
 
-    requestAnimationFrame(onScroll);
-    el.addEventListener('scroll', onScroll, { passive: true });
+    scheduleCompute();
+    el.addEventListener('scroll', scheduleCompute, { passive: true });
 
-    return () => el.removeEventListener('scroll', onScroll);
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+      el.removeEventListener('scroll', scheduleCompute);
+    };
   }, [compute]);
 
   return { isVisible };


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #360 

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

### ✔ 문제

현재 구현 방식은 requestAnimationFrame으로 초기 1회(onScroll)를 실행해 첫 상태를 맞춘 뒤,

이후에는 scroll 이벤트가 발생할 때마다 compute(el.scrollTop)를 즉시 호출한다.

즉, 지금 코드는 rAF-throttle 구조가 아니다.

requestAnimationFrame은 초기 동기화 용도로만 사용되고, 스크롤 핸들링 자체는 이벤트 빈도에 그대로 반응한다.

> 
> 
> 
> **rAF-throttle**
> 
> scroll 이벤트가 아무리 많이 발생해도, requestAnimationFrame을 이용해서 “프레임당 1번만 실행”되도록 제한하는 기법
> 


<img width="419" height="793" alt="스크린샷 2026-02-20 오후 3 38 57" src="https://github.com/user-attachments/assets/4c2a86a7-54a1-4b75-b1d7-1adb1374c035" />



`장점`

- 구현이 단순하다.
- scrollTop > 8 같은 threshold 로직이 직관적이다.
- 특정 스크롤 컨테이너(app-scroll) 기준으로 제어하기 쉽다.

`현재 방식의 한계`

- scroll 이벤트는 프레임 내에서 여러 번 발생할 수 있다.
- 핸들러가 매번 실행되며, scrollTop 읽기 + 상태 계산이 반복된다.
- 특히 모바일 Safari처럼 메인 스레드 여유가 적은 환경에서 누적 비용이 커질 수 있다.
- setState는 같은 값이면 리렌더가 생략될 수 있지만, 핸들러 실행 비용 자체는 계속 발생한다.

### ✔ 방안 검토

- 대안 1: **IntersectionObserver**
    - scroll 이벤트를 직접 처리하지 않는다.
    - 브라우저가 교차 여부를 최적화된 시점에 계산한다.
    - 고빈도 스크롤 구간에서 JS 실행 횟수를 줄일 수 있다.
    - scrollTop 같은 수동 레이아웃 읽기 로직을 직접 두지 않아도 된다.
    - 섹션 진입/이탈 기반 UI에 특히 유리하다.
    - 단, 단순 임계값(scrollTop > 8)은 sentinel/rootMargin 설계가 필요해 구현이 약간 우회적이다.

- 대안 2: **rAF-throttle**
    - 기존 scroll 기반 로직을 유지하면서, 계산을 프레임당 1회로 제한한다.
    - 구현 변경 폭이 작고 현재 코드에 적용이 쉽다.
    - 임계값 기반(scrollTop > 8) 제어가 직관적이다.
    - 이벤트 폭주 시 핸들러/상태 계산 호출 수를 줄여 메인 스레드 부담을 완화한다.
    - 단, scroll 이벤트 자체는 계속 발생하므로 완전한 이벤트 비의존 구조는 아니다.

```
//이전
Frame 1:
scroll → compute
scroll → compute
scroll → compute
```

```
//이후
Frame 1:
scroll
scroll
scroll

→ rAF 콜백 1번
→ compute 1번
```

### ✔ 해결 방법

대안 2(rAF-throttle)가 더 적합하다고 판단하였습니다.

- 현재 요구사항이 단순한 scrollTop > 8 임계값이라 로직이 직관적으로 유지됩니다.
- 기존 훅을 거의 유지하면서 성능 개선(프레임당 1회 계산)이 가능합니다.
- IntersectionObserver는 이 케이스에선 sentinel/rootMargin 설계가 오히려 복잡도를 늘린다고 생각합니다.

### ✔ 검증

- JS 실행 빈도 감소 = 스크롤 이벤트마다 실행되던 계산을 프레임당 1회로 제한
- 메인 스레드 점유율 감소 = 스크롤 중 핸들러 호출 누적 비용 완화
- 렌더링 안정성 개선 =  프레임 타이밍에 맞춰 처리해서 프레임 드랍 가능성 감소
- React 업데이트 부담 감소 = setState 시도 횟수 감소

### ✔ 회고 및 개선 방향

 다만 scroll 이벤트 기반 자체는 유지되므로, 더 복잡한 스크롤 연동 UI가 늘어나면 IntersectionObserver 전환을 재검토할게요.