### PR TITLE
🎀 Feat (web) : #420 AUTH 관련 API 연동

### DIFF
--- a/apps/web/src/app/(auth)/ai-curation/[step]/api/index.ts
+++ b/apps/web/src/app/(auth)/ai-curation/[step]/api/index.ts
@@ -2,17 +2,17 @@
 
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { apiRequest } from '@/api/apiRequest';
-import { USER_QUERY_KEY } from '@/query-key/user';
 import {
   ApiResponseBodyGetAllCurationQuestionsResponseVoid,
   GetCurationQuestionPhotosResponse,
   CreateMoodCurationResponse,
   ApiResponseBodyCreateMoodCurationResponseVoid,
 } from '@/swagger-api';
+import { AUTH_QUERY_KEY } from '@/query-key/auth';
 
 export const useGetAiCurationAll = () => {
   return useQuery<GetCurationQuestionPhotosResponse[]>({
-    queryKey: USER_QUERY_KEY.AI_CURATION_ALL(),
+    queryKey: AUTH_QUERY_KEY.AI_CURATION_ALL(),
     queryFn: async () => {
       const res = await apiRequest<ApiResponseBodyGetAllCurationQuestionsResponseVoid>({
         endPoint: '/api/v1/curation/all',
@@ -33,7 +33,7 @@ export const useGetAiCurationAllPrefetch = () => {
 
   return () => {
     queryClient.prefetchQuery({
-      queryKey: USER_QUERY_KEY.AI_CURATION_ALL(),
+      queryKey: AUTH_QUERY_KEY.AI_CURATION_ALL(),
       queryFn: useGetAiCurationAll,
     });
   };
@@ -54,7 +54,7 @@ export const usePostAiCuration = () => {
       return res.data;
     },
     onSuccess: (data) => {
-      queryClient.setQueryData(USER_QUERY_KEY.AI_CURATION_RESULT(), data);
+      queryClient.setQueryData(AUTH_QUERY_KEY.AI_CURATION_RESULT(), data);
     },
   });
 };

--- a/apps/web/src/app/(auth)/ai-curation/[step]/api/index.ts
+++ b/apps/web/src/app/(auth)/ai-curation/[step]/api/index.ts
@@ -40,8 +40,6 @@ export const useGetAiCurationAllPrefetch = () => {
 };
 
 export const usePostAiCuration = () => {
-  const queryClient = useQueryClient();
-
   return useMutation<CreateMoodCurationResponse, Error, number[]>({
     mutationFn: async (photoIds: number[]) => {
       const res = await apiRequest<ApiResponseBodyCreateMoodCurationResponseVoid>({
@@ -52,9 +50,6 @@ export const usePostAiCuration = () => {
 
       if (!res.data) throw new Error('No data from POST /api/v1/curation');
       return res.data;
-    },
-    onSuccess: (data) => {
-      queryClient.setQueryData(AUTH_QUERY_KEY.AI_CURATION_RESULT(), data);
     },
   });
 };

--- a/apps/web/src/app/(auth)/ai-curation/[step]/components/client-footer/ClientFooter.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/[step]/components/client-footer/ClientFooter.tsx
@@ -4,9 +4,9 @@ import { useRouter } from 'next/navigation';
 import { BottomCTAButton } from '@snappin/design-system';
 import { useToast } from '@/ui';
 import { ROUTES } from '@/constants/routes/routes';
-import { type STEP, TOTAL_STEP_COUNT } from '../../constants/steps';
-import { useAiCuration } from '../../../hooks/useAiCuration';
-import { usePostAiCuration } from '../../api';
+import { type STEP, TOTAL_STEP_COUNT } from '@/app/(auth)/ai-curation/[step]/constants/steps';
+import { useAiCuration } from '@/app/(auth)/ai-curation/hooks/useAiCuration';
+import { usePostAiCuration } from '@/app/(auth)/ai-curation/[step]/api';
 
 type ClientFooterProps = {
   step: STEP;

--- a/apps/web/src/app/(auth)/ai-curation/[step]/components/image-animation/ImageAnimation.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/[step]/components/image-animation/ImageAnimation.tsx
@@ -13,9 +13,7 @@ type ImageAnimationProps = {
 };
 export default function ImageAnimation({ step }: ImageAnimationProps) {
   const { data } = useGetAiCurationAll();
-  //TODO: API 명세 확정되면 question은 목업으로 변경
-  const question = data?.[step - 1];
-  const photos = question?.photos;
+  const photos = data?.[step - 1]?.photos;
   const { error } = useToast();
   const sorted = useMemo(
     () => photos?.slice().sort((a, b) => (a.order ?? 0) - (b.order ?? 0)) || [],

--- a/apps/web/src/app/(auth)/ai-curation/[step]/components/image-animation/ImageAnimation.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/[step]/components/image-animation/ImageAnimation.tsx
@@ -4,9 +4,9 @@ import Image from 'next/image';
 import { useEffect, useMemo, useState, startTransition } from 'react';
 import { cn } from '@snappin/design-system/lib/cn';
 import { useToast } from '@/ui';
-import { useGetAiCurationAll } from '../../api';
-import { type STEP } from '../../constants/steps';
-import { useAiCuration } from '../../../hooks/useAiCuration';
+import { useGetAiCurationAll } from '@/app/(auth)/ai-curation/[step]/api';
+import { type STEP } from '@/app/(auth)/ai-curation/[step]/constants/steps';
+import { useAiCuration } from '@/app/(auth)/ai-curation/hooks/useAiCuration';
 
 type ImageAnimationProps = {
   step: STEP;

--- a/apps/web/src/app/(auth)/ai-curation/[step]/components/step-header/StepHeader.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/[step]/components/step-header/StepHeader.tsx
@@ -1,6 +1,6 @@
 import { formatNumber } from '@snappin/shared/lib';
-import { STEP_QUESTIONS, type STEP } from '../../constants/steps';
-import { getProgress } from '../../utils/steps';
+import { STEP_QUESTIONS, type STEP } from '@/app/(auth)/ai-curation/[step]/constants/steps';
+import { getProgress } from '@/app/(auth)/ai-curation/[step]/utils/steps';
 
 type StepHeaderProps = {
   step: STEP;

--- a/apps/web/src/app/(auth)/ai-curation/[step]/page.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/[step]/page.tsx
@@ -11,11 +11,12 @@ type Props = {
 
 export default async function Page({ params }: Props) {
   const { step } = await params;
-  const aiCurationStep = Number(step) as STEP;
+  const stepNumber = Number(step);
 
-  if (!aiCurationStep || !isAiCurationStep(aiCurationStep)) {
+  if (!stepNumber || !isAiCurationStep(stepNumber)) {
     notFound();
   }
+  const aiCurationStep = stepNumber as STEP;
 
   return (
     <div className='bg-black-10 flex h-dvh flex-col px-[2rem] pt-[3rem] pb-[2rem]'>

--- a/apps/web/src/app/(auth)/ai-curation/[step]/page.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/[step]/page.tsx
@@ -1,9 +1,9 @@
 import { notFound } from 'next/navigation';
-import { type STEP } from './constants/steps';
-import { isAiCurationStep } from './utils/steps';
-import StepHeader from './components/step-header/StepHeader';
-import ClientFooter from './components/client-footer/ClientFooter';
-import ImageAnimation from './components/image-animation/ImageAnimation';
+import { type STEP } from '@/app/(auth)/ai-curation/[step]/constants/steps';
+import { isAiCurationStep } from '@/app/(auth)/ai-curation/[step]/utils/steps';
+import StepHeader from '@/app/(auth)/ai-curation/[step]/components/step-header/StepHeader';
+import ClientFooter from '@/app/(auth)/ai-curation/[step]/components/client-footer/ClientFooter';
+import ImageAnimation from '@/app/(auth)/ai-curation/[step]/components/image-animation/ImageAnimation';
 
 type Props = {
   params: Promise<{ step: string }>;
@@ -11,7 +11,7 @@ type Props = {
 
 export default async function Page({ params }: Props) {
   const { step } = await params;
-  const aiCurationStep = Number(step);
+  const aiCurationStep = Number(step) as STEP;
 
   if (!aiCurationStep || !isAiCurationStep(aiCurationStep)) {
     notFound();
@@ -19,9 +19,9 @@ export default async function Page({ params }: Props) {
 
   return (
     <div className='bg-black-10 flex h-dvh flex-col px-[2rem] pt-[3rem] pb-[2rem]'>
-      <StepHeader step={aiCurationStep as STEP} />
-      <ImageAnimation step={aiCurationStep as STEP} />
-      <ClientFooter step={aiCurationStep as STEP} />
+      <StepHeader step={aiCurationStep} />
+      <ImageAnimation step={aiCurationStep} />
+      <ClientFooter step={aiCurationStep} />
     </div>
   );
 }

--- a/apps/web/src/app/(auth)/ai-curation/[step]/utils/steps.ts
+++ b/apps/web/src/app/(auth)/ai-curation/[step]/utils/steps.ts
@@ -1,4 +1,4 @@
-import { type STEP, TOTAL_STEP_COUNT } from '../constants/steps';
+import { type STEP, TOTAL_STEP_COUNT } from '@/app/(auth)/ai-curation/[step]/constants/steps';
 
 export const isAiCurationStep = (step: number): boolean => {
   return step >= 1 && step <= TOTAL_STEP_COUNT;

--- a/apps/web/src/app/(auth)/ai-curation/components/client-footer/ClientFooter.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/components/client-footer/ClientFooter.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation';
 import { Button, BottomCTAButton } from '@snappin/design-system';
 import { useAuth } from '@/auth/hooks/useAuth';
 import { ROUTES } from '@/constants/routes/routes';
-import { useGetAiCurationAllPrefetch } from '../../[step]/api';
+import { useGetAiCurationAllPrefetch } from '@/app/(auth)/ai-curation/[step]/api';
 
 export default function ClientFooter() {
   const router = useRouter();

--- a/apps/web/src/app/(auth)/ai-curation/hooks/useAiCuration.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/hooks/useAiCuration.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
-import { STEP_QUESTIONS, type STEP } from '../[step]/constants/steps';
+import { STEP_QUESTIONS, type STEP } from '@/app/(auth)/ai-curation/[step]/constants/steps';
 
 type SelectedImage = Record<STEP, number | null>;
 

--- a/apps/web/src/app/(auth)/ai-curation/page.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/page.tsx
@@ -1,5 +1,5 @@
 ﻿import { Logo } from '@snappin/design-system/assets';
-import { ClientFooter, ClientHeader, LottieAnimation } from './components';
+import { ClientFooter, ClientHeader, LottieAnimation } from '@/app/(auth)/ai-curation/components';
 
 export default function Page() {
   return (

--- a/apps/web/src/app/(auth)/ai-curation/provider.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AiCurationProvider } from './hooks/useAiCuration';
+import { AiCurationProvider } from '@/app/(auth)/ai-curation/hooks/useAiCuration';
 
 export default function AiCurationProviders({ children }: { children: React.ReactNode }) {
   return <AiCurationProvider>{children}</AiCurationProvider>;

--- a/apps/web/src/app/(auth)/ai-curation/result/api/index.ts
+++ b/apps/web/src/app/(auth)/ai-curation/result/api/index.ts
@@ -4,11 +4,11 @@ import type {
   ApiResponseBodyCreateMoodCurationResponseVoid,
   CreateMoodCurationResponse,
 } from '@/swagger-api';
-import { USER_QUERY_KEY } from '@/query-key/user';
+import { AUTH_QUERY_KEY } from '@/query-key/auth';
 
 export const useGetAiCurationResult = () => {
   return useQuery<CreateMoodCurationResponse>({
-    queryKey: USER_QUERY_KEY.AI_CURATION_RESULT(),
+    queryKey: AUTH_QUERY_KEY.AI_CURATION_RESULT(),
     queryFn: async () => {
       const res = await apiRequest<ApiResponseBodyCreateMoodCurationResponseVoid>({
         endPoint: '/api/v1/curation/result',

--- a/apps/web/src/app/(auth)/ai-curation/result/components/mood-animation-pending-state/MoodAnimationPending.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/result/components/mood-animation-pending-state/MoodAnimationPending.tsx
@@ -22,8 +22,8 @@ export default function MoodAnimationPending() {
     >
       <Lottie animationData={curationLoadingAnimation} className='h-[7rem] w-[7rem]' />
       <div className='mt-[3rem] flex flex-col items-center gap-[0.3rem]'>
-        <span className='caption-12-md text-black-7'>?먭뎄?먭뎄</span>
-        <h1 className='title-23-eb text-black-10'>臾대뱶 ?먮젅?댁뀡 寃곌낵??..</h1>
+        <span className='caption-12-md text-black-7'>두구두구</span>
+        <h1 className='title-23-eb text-black-10'>무드 큐레이션 결과는..</h1>
       </div>
     </motion.div>
   );

--- a/apps/web/src/app/(auth)/ai-curation/result/components/mood-animation-result-state/MoodAnimationResult.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/result/components/mood-animation-result-state/MoodAnimationResult.tsx
@@ -16,7 +16,7 @@ import {
 import type { CreateMoodCurationResponse } from '@/swagger-api';
 import { ROUTES } from '@/constants/routes/routes';
 import { MoodCode } from '@snappin/shared/types';
-import MoodChip from '../mood-chip/MoodChip';
+import MoodChip from '@/app/(auth)/ai-curation/result/components/mood-chip/MoodChip';
 
 type MoodAnimationResultProps = { data: CreateMoodCurationResponse };
 

--- a/apps/web/src/app/(auth)/ai-curation/result/page.tsx
+++ b/apps/web/src/app/(auth)/ai-curation/result/page.tsx
@@ -2,9 +2,9 @@
 
 import { useEffect, useState, startTransition } from 'react';
 import { AnimatePresence } from 'framer-motion';
-import MoodAnimationResult from './components/mood-animation-result-state/MoodAnimationResult';
-import MoodAnimationPending from './components/mood-animation-pending-state/MoodAnimationPending';
-import { useGetAiCurationResult } from './api';
+import MoodAnimationResult from '@/app/(auth)/ai-curation/result/components/mood-animation-result-state/MoodAnimationResult';
+import MoodAnimationPending from '@/app/(auth)/ai-curation/result/components/mood-animation-pending-state/MoodAnimationPending';
+import { useGetAiCurationResult } from '@/app/(auth)/ai-curation/result/api';
 
 export default function Page() {
   const { data } = useGetAiCurationResult();

--- a/apps/web/src/app/(auth)/login/callback/KakaoCallbackPage.tsx
+++ b/apps/web/src/app/(auth)/login/callback/KakaoCallbackPage.tsx
@@ -8,7 +8,7 @@ import { SERVER_API_BASE_URL } from '@/api/constants/api';
 import { setAuthUser } from '@/auth/userType';
 import { setAccessToken } from '@/auth/token';
 import { useKakaoLogin } from '@/auth/apis';
-import { parseReturnToState, buildReturnToParams, resolveReturnToPath } from '@/auth/utils/returnTo';
+import { getReturnToParam, readReturnToContext, resolveReturnToPath } from '@/auth/utils/returnTo';
 import { useToast, Loading } from '@/ui';
 import { PHOTOGRAPHERS_ROUTES, ROUTES } from '@/constants/routes/routes';
 
@@ -27,7 +27,7 @@ export default function KakaoCallbackPage() {
   const code = params.get('code');
   const error = params.get('error');
   const state = params.get('state');
-  const returnToContext = parseReturnToState(state);
+  const returnToContext = readReturnToContext(new URLSearchParams(state ?? ''));
 
   const startedRef = useRef(false);
 
@@ -41,7 +41,7 @@ export default function KakaoCallbackPage() {
       router.replace(
         ROUTES.LOGIN({
           error: 'kakao',
-          ...buildReturnToParams(returnToContext),
+          ...getReturnToParam(returnToContext),
         }),
       );
       return;
@@ -69,7 +69,7 @@ export default function KakaoCallbackPage() {
         });
 
         if (!data.data.isOnboardingCompleted) {
-          router.replace(ROUTES.ON_BOARDING(1, buildReturnToParams(returnToContext)));
+          router.replace(ROUTES.ON_BOARDING(1, getReturnToParam(returnToContext)));
         } else if (returnToContext.returnTo) {
           router.replace(resolveReturnToPath(returnToContext, ROUTES.HOME));
         } else if (data.data.role === USER_TYPE.PHOTOGRAPHER) {
@@ -81,7 +81,7 @@ export default function KakaoCallbackPage() {
         router.replace(
           ROUTES.LOGIN({
             error: 'kakao',
-            ...buildReturnToParams(returnToContext),
+            ...getReturnToParam(returnToContext),
           }),
         );
         toast.error(

--- a/apps/web/src/app/(auth)/login/callback/KakaoCallbackPage.tsx
+++ b/apps/web/src/app/(auth)/login/callback/KakaoCallbackPage.tsx
@@ -13,7 +13,7 @@ import { PHOTOGRAPHERS_ROUTES, ROUTES } from '@/constants/routes/routes';
 
 const CLIENT_REDIRECT_URI = process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URL;
 const KAKAO_LOGIN_URL =
-  `${SERVER_API_BASE_URL}/api/v1/auth/login/kakao` +
+  `${SERVER_API_BASE_URL}/api/v2/auth/login/kakao` +
   `?redirect_uri=${encodeURIComponent(CLIENT_REDIRECT_URI!)}`;
 
 export default function KakaoCallbackPage() {
@@ -55,14 +55,13 @@ export default function KakaoCallbackPage() {
         if (!isValidUserType(data.data.role)) {
           throw new Error(`Invalid role: ${data.data.role}`);
         }
-        // TODO: 서버 응답에 hasPhotographerProfile 있으면 그걸로 교체
         setAuthUser({
           role: data.data.role as UserType,
-          hasPhotographerProfile: true,
+          hasPhotographerProfile: data.data.hasPhotographerProfile ?? false,
         });
 
-        if (data.data.isNew) {
-          router.replace(ROUTES.AI_CURATION);
+        if (!data.data.isOnboardingCompleted) {
+          router.replace(ROUTES.ON_BOARDING(1));
         } else if (data.data.role === USER_TYPE.PHOTOGRAPHER) {
           router.replace(PHOTOGRAPHERS_ROUTES.RESERVATIONS());
         } else {

--- a/apps/web/src/app/(auth)/login/callback/KakaoCallbackPage.tsx
+++ b/apps/web/src/app/(auth)/login/callback/KakaoCallbackPage.tsx
@@ -8,6 +8,7 @@ import { SERVER_API_BASE_URL } from '@/api/constants/api';
 import { setAuthUser } from '@/auth/userType';
 import { setAccessToken } from '@/auth/token';
 import { useKakaoLogin } from '@/auth/apis';
+import { parseReturnToState, buildReturnToParams, resolveReturnToPath } from '@/auth/utils/returnTo';
 import { useToast, Loading } from '@/ui';
 import { PHOTOGRAPHERS_ROUTES, ROUTES } from '@/constants/routes/routes';
 
@@ -25,6 +26,8 @@ export default function KakaoCallbackPage() {
 
   const code = params.get('code');
   const error = params.get('error');
+  const state = params.get('state');
+  const returnToContext = parseReturnToState(state);
 
   const startedRef = useRef(false);
 
@@ -35,7 +38,12 @@ export default function KakaoCallbackPage() {
 
     if (error) {
       startedRef.current = true;
-      router.replace(ROUTES.LOGIN({ error: 'kakao' }));
+      router.replace(
+        ROUTES.LOGIN({
+          error: 'kakao',
+          ...buildReturnToParams(returnToContext),
+        }),
+      );
       return;
     }
 
@@ -61,14 +69,21 @@ export default function KakaoCallbackPage() {
         });
 
         if (!data.data.isOnboardingCompleted) {
-          router.replace(ROUTES.ON_BOARDING(1));
+          router.replace(ROUTES.ON_BOARDING(1, buildReturnToParams(returnToContext)));
+        } else if (returnToContext.returnTo) {
+          router.replace(resolveReturnToPath(returnToContext, ROUTES.HOME));
         } else if (data.data.role === USER_TYPE.PHOTOGRAPHER) {
           router.replace(PHOTOGRAPHERS_ROUTES.RESERVATIONS());
         } else {
           router.replace(ROUTES.HOME);
         }
       } catch {
-        router.replace(ROUTES.LOGIN({ error: 'kakao' }));
+        router.replace(
+          ROUTES.LOGIN({
+            error: 'kakao',
+            ...buildReturnToParams(returnToContext),
+          }),
+        );
         toast.error(
           '카카오 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.',
           undefined,
@@ -76,7 +91,7 @@ export default function KakaoCallbackPage() {
         );
       }
     })();
-  }, [code, error, mutateAsync, router, toast]);
+  }, [code, error, mutateAsync, returnToContext, router, toast]);
 
   return (
     <div className='bg-black-10 flex h-dvh flex-col items-center justify-center gap-[1.5rem]'>

--- a/apps/web/src/app/(auth)/login/components/client-login-button/LoginButton.tsx
+++ b/apps/web/src/app/(auth)/login/components/client-login-button/LoginButton.tsx
@@ -1,16 +1,21 @@
 ﻿'use client';
 
+import { useSearchParams } from 'next/navigation';
 import { BottomCTAButton } from '@snappin/design-system';
 import { IconKakao } from '@snappin/design-system/assets';
+import { readReturnToContext, serializeReturnToState } from '@/auth/utils/returnTo';
 
 export default function LoginButton() {
+  const searchParams = useSearchParams();
   const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!;
   const redirectUri = process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URL!;
+  const state = serializeReturnToState(readReturnToContext(searchParams));
   const KAKAO_LOGIN_URL =
     `https://kauth.kakao.com/oauth/authorize` +
     `?response_type=code` +
     `&client_id=${clientId}` +
-    `&redirect_uri=${encodeURIComponent(redirectUri)}`;
+    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    (state ? `&state=${encodeURIComponent(state)}` : '');
 
   const handleLogin = () => {
     window.location.href = KAKAO_LOGIN_URL;

--- a/apps/web/src/app/(auth)/login/components/client-login-button/LoginButton.tsx
+++ b/apps/web/src/app/(auth)/login/components/client-login-button/LoginButton.tsx
@@ -3,13 +3,14 @@
 import { useSearchParams } from 'next/navigation';
 import { BottomCTAButton } from '@snappin/design-system';
 import { IconKakao } from '@snappin/design-system/assets';
-import { readReturnToContext, serializeReturnToState } from '@/auth/utils/returnTo';
+import { readReturnToContext } from '@/auth/utils/returnTo';
 
 export default function LoginButton() {
   const searchParams = useSearchParams();
   const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!;
   const redirectUri = process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URL!;
-  const state = serializeReturnToState(readReturnToContext(searchParams));
+  const { returnTo } = readReturnToContext(searchParams);
+  const state = returnTo ? new URLSearchParams({ returnTo }).toString() : '';
   const KAKAO_LOGIN_URL =
     `https://kauth.kakao.com/oauth/authorize` +
     `?response_type=code` +

--- a/apps/web/src/app/(auth)/login/components/client-login-button/LoginButton.tsx
+++ b/apps/web/src/app/(auth)/login/components/client-login-button/LoginButton.tsx
@@ -1,15 +1,15 @@
 ﻿'use client';
 
-import { useSearchParams } from 'next/navigation';
 import { BottomCTAButton } from '@snappin/design-system';
 import { IconKakao } from '@snappin/design-system/assets';
-import { readReturnToContext } from '@/auth/utils/returnTo';
 
-export default function LoginButton() {
-  const searchParams = useSearchParams();
+type LoginButtonProps = {
+  returnTo?: string;
+};
+
+export default function LoginButton({ returnTo }: LoginButtonProps) {
   const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID!;
   const redirectUri = process.env.NEXT_PUBLIC_KAKAO_LOGIN_REDIRECT_URL!;
-  const { returnTo } = readReturnToContext(searchParams);
   const state = returnTo ? new URLSearchParams({ returnTo }).toString() : '';
   const KAKAO_LOGIN_URL =
     `https://kauth.kakao.com/oauth/authorize` +

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,8 +1,22 @@
 ﻿import { Logo } from '@snappin/design-system/assets';
 import { ImageSlide } from '@snappin/design-system';
+import { readReturnToContext } from '@/auth/utils/returnTo';
 import { ClientNavigation, LoginButton } from './components';
 
-export default function Page() {
+type PageProps = {
+  searchParams: Promise<{
+    returnTo?: string;
+  }>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
+  const { returnTo: rawReturnTo } = await searchParams;
+  const returnTo = readReturnToContext(
+    new URLSearchParams({
+      returnTo: rawReturnTo ?? '',
+    }),
+  ).returnTo;
+
   return (
     <div className='bg-black-10 h-full'>
       <ClientNavigation />
@@ -13,7 +27,7 @@ export default function Page() {
         </div>
         <ImageSlide />
         <div className='flex justify-center px-[2rem]'>
-          <LoginButton />
+          <LoginButton returnTo={returnTo} />
         </div>
       </div>
     </div>

--- a/apps/web/src/app/(auth)/on-boarding/[step]/api/index.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/api/index.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiRequest } from '@/api/apiRequest';
+import { ApiResponseBodyGetOnboardingResponseVoid, CreateOnboardingRequest } from '@/swagger-api';
+import { AUTH_QUERY_KEY } from '@/query-key/auth';
+
+export const usePostOnboarding = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: CreateOnboardingRequest) => {
+      const res = await apiRequest<ApiResponseBodyGetOnboardingResponseVoid>({
+        endPoint: '/api/v1/users/onboarding',
+        method: 'POST',
+        data,
+      });
+
+      if (!res.success) {
+        throw new Error('No data from POST /api/v1/users/onboarding');
+      }
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(AUTH_QUERY_KEY.ONBOARDING(), data);
+    },
+  });
+};

--- a/apps/web/src/app/(auth)/on-boarding/[step]/api/index.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/api/index.ts
@@ -5,10 +5,15 @@ import { apiRequest } from '@/api/apiRequest';
 import { ApiResponseBodyVoidVoid, CreateOnboardingRequest } from '@/swagger-api';
 import { AUTH_QUERY_KEY } from '@/query-key/auth';
 
-export const usePostOnboarding = () => {
+type UsePostOnboardingOptions = {
+  onSuccess?: () => void | Promise<void>;
+  onError?: (error: Error) => void | Promise<void>;
+};
+
+export const usePostOnboarding = (options?: UsePostOnboardingOptions) => {
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<boolean, Error, CreateOnboardingRequest>({
     mutationFn: async (data: CreateOnboardingRequest) => {
       const res = await apiRequest<ApiResponseBodyVoidVoid>({
         endPoint: '/api/v1/users/onboarding',
@@ -22,8 +27,15 @@ export const usePostOnboarding = () => {
 
       return true;
     },
-    onSuccess: () => {
+    onSuccess: async () => {
       queryClient.setQueryData(AUTH_QUERY_KEY.ONBOARDING(), true);
+
+      await options?.onSuccess?.();
+    },
+    onError: async (error) => {
+      queryClient.setQueryData(AUTH_QUERY_KEY.ONBOARDING(), false);
+
+      await options?.onError?.(error);
     },
   });
 };

--- a/apps/web/src/app/(auth)/on-boarding/[step]/api/index.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/api/index.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiRequest } from '@/api/apiRequest';
-import { ApiResponseBodyGetOnboardingResponseVoid, CreateOnboardingRequest } from '@/swagger-api';
+import { ApiResponseBodyVoidVoid, CreateOnboardingRequest } from '@/swagger-api';
 import { AUTH_QUERY_KEY } from '@/query-key/auth';
 
 export const usePostOnboarding = () => {
@@ -10,7 +10,7 @@ export const usePostOnboarding = () => {
 
   return useMutation({
     mutationFn: async (data: CreateOnboardingRequest) => {
-      const res = await apiRequest<ApiResponseBodyGetOnboardingResponseVoid>({
+      const res = await apiRequest<ApiResponseBodyVoidVoid>({
         endPoint: '/api/v1/users/onboarding',
         method: 'POST',
         data,
@@ -19,9 +19,11 @@ export const usePostOnboarding = () => {
       if (!res.success) {
         throw new Error('No data from POST /api/v1/users/onboarding');
       }
+
+      return true;
     },
-    onSuccess: (data) => {
-      queryClient.setQueryData(AUTH_QUERY_KEY.ONBOARDING(), data);
+    onSuccess: () => {
+      queryClient.setQueryData(AUTH_QUERY_KEY.ONBOARDING(), true);
     },
   });
 };

--- a/apps/web/src/app/(auth)/on-boarding/[step]/components/client-footer/ClientFooter.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/components/client-footer/ClientFooter.tsx
@@ -6,6 +6,8 @@ import { ROUTES } from '@/constants/routes/routes';
 import { TOTAL_STEP_COUNT } from '@/app/(auth)/on-boarding/[step]/constants/onBoardingSteps';
 import type { OnBoardingStep } from '@/app/(auth)/on-boarding/[step]/types/onBoardingStep';
 import { useOnBoardingFormContext } from '@/app/(auth)/on-boarding/hooks/useOnBoardingFormContext';
+import { usePostOnboarding } from '@/app/(auth)/on-boarding/[step]/api';
+import { GenderValue } from '@/app/(auth)/on-boarding/[step]/constants/onBoardingForm.schema';
 
 type ClientFooterProps = {
   step: number;
@@ -14,7 +16,8 @@ type ClientFooterProps = {
 
 export default function ClientFooter({ step, triggerFields }: ClientFooterProps) {
   const router = useRouter();
-  const { trigger } = useOnBoardingFormContext();
+  const { compatibleFormData, trigger, handleSubmitForm } = useOnBoardingFormContext();
+  const { mutateAsync, isPending } = usePostOnboarding();
 
   const isLast = step === TOTAL_STEP_COUNT;
 
@@ -24,8 +27,18 @@ export default function ClientFooter({ step, triggerFields }: ClientFooterProps)
     if (!isValid) return;
 
     if (isLast) {
-      router.push(ROUTES.ON_BOARDING_FINAL);
-      //TODO: API 연동
+      await handleSubmitForm(() => {
+        mutateAsync({
+          name: compatibleFormData.name,
+          gender: compatibleFormData.gender as GenderValue,
+          nickname: compatibleFormData.nickname,
+          email: compatibleFormData.email,
+          snapCategories: compatibleFormData.snapCategories,
+          phoneNumber: compatibleFormData.phoneNumber,
+        });
+
+        router.push(ROUTES.ON_BOARDING_FINAL);
+      });
     } else {
       router.push(ROUTES.ON_BOARDING(step + 1));
     }
@@ -33,7 +46,12 @@ export default function ClientFooter({ step, triggerFields }: ClientFooterProps)
 
   return (
     <BottomCTAButton fixed className='px-[2.7rem] pb-[2.8rem]'>
-      <BottomCTAButton.Single color='black' size='large' onClick={handleNextStep}>
+      <BottomCTAButton.Single
+        color='black'
+        size='large'
+        onClick={handleNextStep}
+        disabled={isPending}
+      >
         다음
       </BottomCTAButton.Single>
     </BottomCTAButton>

--- a/apps/web/src/app/(auth)/on-boarding/[step]/components/client-footer/ClientFooter.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/components/client-footer/ClientFooter.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { BottomCTAButton } from '@snappin/design-system';
+import { buildReturnToParams, readReturnToContext } from '@/auth/utils/returnTo';
 import { ROUTES } from '@/constants/routes/routes';
 import { TOTAL_STEP_COUNT } from '@/app/(auth)/on-boarding/[step]/constants/onBoardingSteps';
 import type { OnBoardingStep } from '@/app/(auth)/on-boarding/[step]/types/onBoardingStep';
@@ -16,6 +17,8 @@ type ClientFooterProps = {
 
 export default function ClientFooter({ step, triggerFields }: ClientFooterProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const returnToParams = buildReturnToParams(readReturnToContext(searchParams));
   const { compatibleFormData, trigger, handleSubmitForm } = useOnBoardingFormContext();
   const { mutateAsync, isPending } = usePostOnboarding();
 
@@ -27,8 +30,8 @@ export default function ClientFooter({ step, triggerFields }: ClientFooterProps)
     if (!isValid) return;
 
     if (isLast) {
-      await handleSubmitForm(() => {
-        mutateAsync({
+      await handleSubmitForm(async () => {
+        await mutateAsync({
           name: compatibleFormData.name,
           gender: compatibleFormData.gender as GenderValue,
           nickname: compatibleFormData.nickname,
@@ -37,10 +40,10 @@ export default function ClientFooter({ step, triggerFields }: ClientFooterProps)
           phoneNumber: compatibleFormData.phoneNumber,
         });
 
-        router.push(ROUTES.ON_BOARDING_FINAL);
+        router.push(ROUTES.ON_BOARDING_FINAL(returnToParams));
       });
     } else {
-      router.push(ROUTES.ON_BOARDING(step + 1));
+      router.push(ROUTES.ON_BOARDING(step + 1, returnToParams));
     }
   };
 

--- a/apps/web/src/app/(auth)/on-boarding/[step]/components/client-footer/ClientFooter.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/components/client-footer/ClientFooter.tsx
@@ -9,6 +9,7 @@ import type { OnBoardingStep } from '@/app/(auth)/on-boarding/[step]/types/onBoa
 import { useOnBoardingFormContext } from '@/app/(auth)/on-boarding/hooks/useOnBoardingFormContext';
 import { usePostOnboarding } from '@/app/(auth)/on-boarding/[step]/api';
 import { GenderValue } from '@/app/(auth)/on-boarding/[step]/constants/onBoardingForm.schema';
+import { useToast } from '@/ui';
 
 type ClientFooterProps = {
   step: number;
@@ -20,7 +21,20 @@ export default function ClientFooter({ step, triggerFields }: ClientFooterProps)
   const searchParams = useSearchParams();
   const returnToParams = getReturnToParam(readReturnToContext(searchParams));
   const { compatibleFormData, trigger, handleSubmitForm } = useOnBoardingFormContext();
-  const { mutateAsync, isPending } = usePostOnboarding();
+  const { error } = useToast();
+
+  const { mutateAsync, isPending } = usePostOnboarding({
+    onSuccess: () => {
+      router.push(ROUTES.ON_BOARDING_FINAL(returnToParams));
+    },
+    onError: () => {
+      error('온보딩에 실패했어요. 홈으로 이동합니다.', undefined, 'bottom-[8.4rem]');
+
+      window.setTimeout(() => {
+        router.push(ROUTES.HOME);
+      }, 2000);
+    },
+  });
 
   const isLast = step === TOTAL_STEP_COUNT;
 
@@ -39,8 +53,6 @@ export default function ClientFooter({ step, triggerFields }: ClientFooterProps)
           snapCategories: compatibleFormData.snapCategories,
           phoneNumber: compatibleFormData.phoneNumber,
         });
-
-        router.push(ROUTES.ON_BOARDING_FINAL(returnToParams));
       });
     } else {
       router.push(ROUTES.ON_BOARDING(step + 1, returnToParams));

--- a/apps/web/src/app/(auth)/on-boarding/[step]/components/client-footer/ClientFooter.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/components/client-footer/ClientFooter.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { BottomCTAButton } from '@snappin/design-system';
-import { buildReturnToParams, readReturnToContext } from '@/auth/utils/returnTo';
+import { getReturnToParam, readReturnToContext } from '@/auth/utils/returnTo';
 import { ROUTES } from '@/constants/routes/routes';
 import { TOTAL_STEP_COUNT } from '@/app/(auth)/on-boarding/[step]/constants/onBoardingSteps';
 import type { OnBoardingStep } from '@/app/(auth)/on-boarding/[step]/types/onBoardingStep';
@@ -18,7 +18,7 @@ type ClientFooterProps = {
 export default function ClientFooter({ step, triggerFields }: ClientFooterProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const returnToParams = buildReturnToParams(readReturnToContext(searchParams));
+  const returnToParams = getReturnToParam(readReturnToContext(searchParams));
   const { compatibleFormData, trigger, handleSubmitForm } = useOnBoardingFormContext();
   const { mutateAsync, isPending } = usePostOnboarding();
 

--- a/apps/web/src/app/(auth)/on-boarding/[step]/components/client-footer/ClientFooter.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/components/client-footer/ClientFooter.tsx
@@ -1,15 +1,16 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { BottomCTAButton } from '@snappin/design-system';
 import { getReturnToParam, readReturnToContext } from '@/auth/utils/returnTo';
 import { ROUTES } from '@/constants/routes/routes';
+import { useToast } from '@/ui';
 import { TOTAL_STEP_COUNT } from '@/app/(auth)/on-boarding/[step]/constants/onBoardingSteps';
 import type { OnBoardingStep } from '@/app/(auth)/on-boarding/[step]/types/onBoardingStep';
 import { useOnBoardingFormContext } from '@/app/(auth)/on-boarding/hooks/useOnBoardingFormContext';
 import { usePostOnboarding } from '@/app/(auth)/on-boarding/[step]/api';
 import { GenderValue } from '@/app/(auth)/on-boarding/[step]/constants/onBoardingForm.schema';
-import { useToast } from '@/ui';
 
 type ClientFooterProps = {
   step: number;
@@ -22,6 +23,15 @@ export default function ClientFooter({ step, triggerFields }: ClientFooterProps)
   const returnToParams = getReturnToParam(readReturnToContext(searchParams));
   const { compatibleFormData, trigger, handleSubmitForm } = useOnBoardingFormContext();
   const { error } = useToast();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   const { mutateAsync, isPending } = usePostOnboarding({
     onSuccess: () => {
@@ -30,7 +40,7 @@ export default function ClientFooter({ step, triggerFields }: ClientFooterProps)
     onError: () => {
       error('온보딩에 실패했어요. 홈으로 이동합니다.', undefined, 'bottom-[8.4rem]');
 
-      window.setTimeout(() => {
+      timeoutRef.current = setTimeout(() => {
         router.push(ROUTES.HOME);
       }, 2000);
     },

--- a/apps/web/src/app/(auth)/on-boarding/[step]/components/on-boarding-fields/OnBoardingFields.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/components/on-boarding-fields/OnBoardingFields.tsx
@@ -7,7 +7,7 @@ import {
 import { useOnBoardingFormContext } from '@/app/(auth)/on-boarding/hooks/useOnBoardingFormContext';
 import {
   GENDER_LABELS,
-  INTEREST_LABELS,
+  SNAP_CATEGORIES_LABELS,
 } from '@/app/(auth)/on-boarding/[step]/constants/onBoardingForm.schema';
 import type {
   OnBoardingField,
@@ -26,15 +26,15 @@ export default function OnBoardingFields({ fields }: Props) {
     updateName,
     updateGender,
     updateNickname,
-    updatePhoneNumber,
+    updatePhone,
     updateEmail,
-    updateInterest,
+    updateSnapCategory,
   } = useOnBoardingFormContext();
 
   const TEXT_FIELD_HANDLERS: Record<OnBoardingTextField['name'], (value: string) => void> = {
     name: updateName,
     nickname: updateNickname,
-    phoneNumber: updatePhoneNumber,
+    phone: updatePhone,
     email: updateEmail,
   };
 
@@ -82,9 +82,9 @@ export default function OnBoardingFields({ fields }: Props) {
             key={field.name}
             label={field.label}
             value={compatibleFormData[field.name]}
-            onChange={updateInterest}
+            onChange={updateSnapCategory}
             options={field.options}
-            labels={INTEREST_LABELS}
+            labels={SNAP_CATEGORIES_LABELS}
             error={Boolean(errorText)}
             errorText={errorText}
           />

--- a/apps/web/src/app/(auth)/on-boarding/[step]/components/on-boarding-fields/OnBoardingFields.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/components/on-boarding-fields/OnBoardingFields.tsx
@@ -26,7 +26,7 @@ export default function OnBoardingFields({ fields }: Props) {
     updateName,
     updateGender,
     updateNickname,
-    updatePhone,
+    updatePhoneNumber,
     updateEmail,
     updateSnapCategory,
   } = useOnBoardingFormContext();
@@ -34,7 +34,7 @@ export default function OnBoardingFields({ fields }: Props) {
   const TEXT_FIELD_HANDLERS: Record<OnBoardingTextField['name'], (value: string) => void> = {
     name: updateName,
     nickname: updateNickname,
-    phone: updatePhone,
+    phoneNumber: updatePhoneNumber,
     email: updateEmail,
   };
 

--- a/apps/web/src/app/(auth)/on-boarding/[step]/constants/onBoardingForm.schema.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/constants/onBoardingForm.schema.ts
@@ -8,20 +8,20 @@ export const SCHEMA = {
 } as const;
 
 export const GENDER_VALUES = ['boy', 'girl'] as const;
-export const INTEREST_VALUES = ['graduation', 'friendship', 'couple', 'life'] as const;
+export const SNAP_CATEGORIES_VALUES = ['GRADUATION', 'FRIENDS', 'COUPLE', 'DAILY'] as const;
 export type GenderValue = (typeof GENDER_VALUES)[number];
-export type InterestValue = (typeof INTEREST_VALUES)[number];
+export type SnapCategoryValue = (typeof SNAP_CATEGORIES_VALUES)[number];
 
 export const GENDER_LABELS: Record<GenderValue, string> = {
   girl: '여자',
   boy: '남자',
 };
 
-export const INTEREST_LABELS: Record<InterestValue, string> = {
-  graduation: '나만의 졸업 스냅',
-  friendship: '친구와의 우정 스냅',
-  couple: '연인과의 커플 스냅',
-  life: '소중한 내 인생 스냅',
+export const SNAP_CATEGORIES_LABELS: Record<SnapCategoryValue, string> = {
+  GRADUATION: '나만의 졸업 스냅',
+  FRIENDS: '친구와의 우정 스냅',
+  COUPLE: '연인과의 커플 스냅',
+  DAILY: '소중한 내 인생 스냅',
 };
 
 export const ERROR_MESSAGES = {
@@ -69,13 +69,13 @@ export const ON_BOARDING_SCHEMA = z.object({
       message: ERROR_MESSAGES.NICKNAME_TEXT,
     }),
 
-  phoneNumber: z.string().refine((value) => PHONE_NUMBER_REGEX.test(value.replace(/-/g, '')), {
+  phone: z.string().refine((value) => PHONE_NUMBER_REGEX.test(value.replace(/-/g, '')), {
     message: ERROR_MESSAGES.PHONE_NUMBER,
   }),
 
   email: z.email(ERROR_MESSAGES.EMAIL),
 
-  interests: z.array(z.enum(INTEREST_VALUES)).min(1, ERROR_MESSAGES.INTERESTS_REQUIRED),
+  snapCategories: z.array(z.enum(SNAP_CATEGORIES_VALUES)).min(1, ERROR_MESSAGES.INTERESTS_REQUIRED),
 });
 
 export type OnBoardingInput = z.infer<typeof ON_BOARDING_SCHEMA>;

--- a/apps/web/src/app/(auth)/on-boarding/[step]/constants/onBoardingForm.schema.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/constants/onBoardingForm.schema.ts
@@ -7,14 +7,14 @@ export const SCHEMA = {
   PHONE_NUMBER_LENGTH: 11,
 } as const;
 
-export const GENDER_VALUES = ['boy', 'girl'] as const;
+export const GENDER_VALUES = ['MALE', 'FEMALE'] as const;
 export const SNAP_CATEGORIES_VALUES = ['GRADUATION', 'FRIENDS', 'COUPLE', 'DAILY'] as const;
 export type GenderValue = (typeof GENDER_VALUES)[number];
 export type SnapCategoryValue = (typeof SNAP_CATEGORIES_VALUES)[number];
 
 export const GENDER_LABELS: Record<GenderValue, string> = {
-  girl: '여자',
-  boy: '남자',
+  FEMALE: '여자',
+  MALE: '남자',
 };
 
 export const SNAP_CATEGORIES_LABELS: Record<SnapCategoryValue, string> = {
@@ -69,7 +69,7 @@ export const ON_BOARDING_SCHEMA = z.object({
       message: ERROR_MESSAGES.NICKNAME_TEXT,
     }),
 
-  phone: z.string().refine((value) => PHONE_NUMBER_REGEX.test(value.replace(/-/g, '')), {
+  phoneNumber: z.string().refine((value) => PHONE_NUMBER_REGEX.test(value.replace(/-/g, '')), {
     message: ERROR_MESSAGES.PHONE_NUMBER,
   }),
 

--- a/apps/web/src/app/(auth)/on-boarding/[step]/constants/onBoardingSteps.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/constants/onBoardingSteps.ts
@@ -46,10 +46,10 @@ export const ON_BOARDING_STEPS = [
     step: 3,
     title: INFO_STEP_TITLE,
     description: INFO_STEP_DESCRIPTION,
-    triggerFields: ['phone'],
+    triggerFields: ['phoneNumber'],
     fields: [
       {
-        name: 'phone',
+        name: 'phoneNumber',
         label: '전화번호',
         placeholder: "'-' 없이 숫자만 입력해주세요",
         type: 'text',

--- a/apps/web/src/app/(auth)/on-boarding/[step]/constants/onBoardingSteps.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/constants/onBoardingSteps.ts
@@ -1,6 +1,6 @@
 import {
   GENDER_VALUES,
-  INTEREST_VALUES,
+  SNAP_CATEGORIES_VALUES,
 } from '@/app/(auth)/on-boarding/[step]/constants/onBoardingForm.schema';
 import type { OnBoardingStep } from '@/app/(auth)/on-boarding/[step]/types/onBoardingStep';
 
@@ -46,10 +46,10 @@ export const ON_BOARDING_STEPS = [
     step: 3,
     title: INFO_STEP_TITLE,
     description: INFO_STEP_DESCRIPTION,
-    triggerFields: ['phoneNumber'],
+    triggerFields: ['phone'],
     fields: [
       {
-        name: 'phoneNumber',
+        name: 'phone',
         label: '전화번호',
         placeholder: "'-' 없이 숫자만 입력해주세요",
         type: 'text',
@@ -74,13 +74,13 @@ export const ON_BOARDING_STEPS = [
     step: 5,
     title: '관심 있는 스냅 촬영을\n모두 선택해 주세요.',
     description: undefined,
-    triggerFields: ['interests'],
+    triggerFields: ['snapCategories'],
     fields: [
       {
-        name: 'interests',
+        name: 'snapCategories',
         label: '',
         type: 'checkbox',
-        options: INTEREST_VALUES,
+        options: SNAP_CATEGORIES_VALUES,
       },
     ],
   },

--- a/apps/web/src/app/(auth)/on-boarding/[step]/hooks/useOnBoardingForm.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/hooks/useOnBoardingForm.ts
@@ -30,7 +30,7 @@ export const useOnBoardingForm = () => {
       name: '',
       gender: undefined,
       nickname: '',
-      phone: '',
+      phoneNumber: '',
       email: '',
       snapCategories: [],
     },
@@ -81,7 +81,7 @@ export const useOnBoardingForm = () => {
     setValue('nickname', value, { shouldValidate: true });
   };
 
-  const updatePhone = (value: string) => {
+  const updatePhoneNumber = (value: string) => {
     const digits = value.replace(/\D/g, '').slice(0, 11);
     let sanitizedValue = digits;
 
@@ -93,7 +93,7 @@ export const useOnBoardingForm = () => {
       sanitizedValue = `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
     }
 
-    setValue('phone', sanitizedValue, { shouldValidate: true });
+    setValue('phoneNumber', sanitizedValue, { shouldValidate: true });
   };
 
   const updateEmail = (value: string) => {
@@ -113,15 +113,16 @@ export const useOnBoardingForm = () => {
     name: formData?.name ?? '',
     gender: formData?.gender ?? '',
     nickname: formData?.nickname ?? '',
-    phone: formData?.phone ?? '',
+    phoneNumber: formData?.phoneNumber ?? '',
     email: formData?.email ?? '',
     snapCategories: formData?.snapCategories ?? [],
   };
+
   const compatibleErrors = {
     name: errors.name?.message,
     gender: errors.gender?.message,
     nickname: errors.nickname?.message,
-    phone: errors.phone?.message,
+    phoneNumber: errors.phoneNumber?.message,
     email: errors.email?.message,
     snapCategories: errors.snapCategories?.message,
   };
@@ -146,7 +147,7 @@ export const useOnBoardingForm = () => {
     updateName,
     updateGender,
     updateNickname,
-    updatePhone,
+    updatePhoneNumber,
     updateEmail,
     updateSnapCategory,
   };

--- a/apps/web/src/app/(auth)/on-boarding/[step]/hooks/useOnBoardingForm.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/hooks/useOnBoardingForm.ts
@@ -127,10 +127,7 @@ export const useOnBoardingForm = () => {
     snapCategories: errors.snapCategories?.message,
   };
 
-  const handleSubmitForm = async (onSuccess: () => void | Promise<void>) => {
-    const isValid = await trigger();
-    if (!isValid) return;
-
+  const handleSubmitForm = (onSuccess: () => void | Promise<void>) => {
     handleSubmit(async () => {
       await onSuccess();
 

--- a/apps/web/src/app/(auth)/on-boarding/[step]/hooks/useOnBoardingForm.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/hooks/useOnBoardingForm.ts
@@ -6,7 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import {
   ERROR_MESSAGES,
   GenderValue,
-  InterestValue,
+  SnapCategoryValue,
   OnBoardingInput,
   SCHEMA,
   ON_BOARDING_SCHEMA,
@@ -30,9 +30,9 @@ export const useOnBoardingForm = () => {
       name: '',
       gender: undefined,
       nickname: '',
-      phoneNumber: '',
+      phone: '',
       email: '',
-      interests: [],
+      snapCategories: [],
     },
     mode: 'onChange',
   });
@@ -81,7 +81,7 @@ export const useOnBoardingForm = () => {
     setValue('nickname', value, { shouldValidate: true });
   };
 
-  const updatePhoneNumber = (value: string) => {
+  const updatePhone = (value: string) => {
     const digits = value.replace(/\D/g, '').slice(0, 11);
     let sanitizedValue = digits;
 
@@ -93,37 +93,37 @@ export const useOnBoardingForm = () => {
       sanitizedValue = `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
     }
 
-    setValue('phoneNumber', sanitizedValue, { shouldValidate: true });
+    setValue('phone', sanitizedValue, { shouldValidate: true });
   };
 
   const updateEmail = (value: string) => {
     setValue('email', value, { shouldValidate: true });
   };
 
-  const updateInterest = (value: InterestValue) => {
-    const currentValues = formData?.interests ?? [];
+  const updateSnapCategory = (value: SnapCategoryValue) => {
+    const currentValues = formData?.snapCategories ?? [];
     const nextValues = currentValues.includes(value)
       ? currentValues.filter((item) => item !== value)
       : [...currentValues, value];
 
-    setValue('interests', nextValues, { shouldValidate: true });
+    setValue('snapCategories', nextValues, { shouldValidate: true });
   };
 
   const compatibleFormData = {
     name: formData?.name ?? '',
     gender: formData?.gender ?? '',
     nickname: formData?.nickname ?? '',
-    phoneNumber: formData?.phoneNumber ?? '',
+    phone: formData?.phone ?? '',
     email: formData?.email ?? '',
-    interests: formData?.interests ?? [],
+    snapCategories: formData?.snapCategories ?? [],
   };
   const compatibleErrors = {
     name: errors.name?.message,
     gender: errors.gender?.message,
     nickname: errors.nickname?.message,
-    phoneNumber: errors.phoneNumber?.message,
+    phone: errors.phone?.message,
     email: errors.email?.message,
-    interests: errors.interests?.message,
+    snapCategories: errors.snapCategories?.message,
   };
 
   const handleSubmitForm = async (onSuccess: () => void | Promise<void>) => {
@@ -146,8 +146,8 @@ export const useOnBoardingForm = () => {
     updateName,
     updateGender,
     updateNickname,
-    updatePhoneNumber,
+    updatePhone,
     updateEmail,
-    updateInterest,
+    updateSnapCategory,
   };
 };

--- a/apps/web/src/app/(auth)/on-boarding/[step]/types/onBoardingStep.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/types/onBoardingStep.ts
@@ -1,13 +1,13 @@
 import type {
   ON_BOARDING_SCHEMA,
   GenderValue,
-  InterestValue,
+  SnapCategoryValue,
 } from '@/app/(auth)/on-boarding/[step]/constants/onBoardingForm.schema';
 
 type OnBoardingFieldName = keyof typeof ON_BOARDING_SCHEMA.shape;
 
 export type OnBoardingTextField = {
-  name: Extract<OnBoardingFieldName, 'name' | 'nickname' | 'phoneNumber' | 'email'>;
+  name: Extract<OnBoardingFieldName, 'name' | 'nickname' | 'phone' | 'email'>;
   label: string;
   placeholder: string;
   type: 'text';
@@ -21,7 +21,7 @@ export type OnBoardingSelectField<T extends string = string> = {
 };
 
 export type OnBoardingCheckboxField<T extends string = string> = {
-  name: Extract<OnBoardingFieldName, 'interests'>;
+  name: Extract<OnBoardingFieldName, 'snapCategories'>;
   label: string;
   type: 'checkbox';
   options: readonly T[];
@@ -30,7 +30,7 @@ export type OnBoardingCheckboxField<T extends string = string> = {
 export type OnBoardingField =
   | OnBoardingTextField
   | OnBoardingSelectField<GenderValue>
-  | OnBoardingCheckboxField<InterestValue>;
+  | OnBoardingCheckboxField<SnapCategoryValue>;
 
 export type OnBoardingStep = {
   step: number;

--- a/apps/web/src/app/(auth)/on-boarding/[step]/types/onBoardingStep.ts
+++ b/apps/web/src/app/(auth)/on-boarding/[step]/types/onBoardingStep.ts
@@ -7,7 +7,7 @@ import type {
 type OnBoardingFieldName = keyof typeof ON_BOARDING_SCHEMA.shape;
 
 export type OnBoardingTextField = {
-  name: Extract<OnBoardingFieldName, 'name' | 'nickname' | 'phone' | 'email'>;
+  name: Extract<OnBoardingFieldName, 'name' | 'nickname' | 'phoneNumber' | 'email'>;
   label: string;
   placeholder: string;
   type: 'text';

--- a/apps/web/src/app/(auth)/on-boarding/components/client-navigation/ClientNavigation.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/components/client-navigation/ClientNavigation.tsx
@@ -1,26 +1,29 @@
 ﻿'use client';
 
-import { useParams, usePathname, useRouter } from 'next/navigation';
+import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { IconArrowBack } from '@snappin/design-system/assets';
 import { Navigation } from '@snappin/design-system';
+import { buildReturnToParams, readReturnToContext } from '@/auth/utils/returnTo';
 import { ROUTES } from '@/constants/routes/routes';
 
 export default function ClientNavigation() {
   const router = useRouter();
   const pathname = usePathname();
   const params = useParams<{ step?: string }>();
+  const searchParams = useSearchParams();
+  const returnToParams = buildReturnToParams(readReturnToContext(searchParams));
 
-  const isBackHidden = params.step === '1' || pathname === ROUTES.ON_BOARDING_FINAL;
+  const isBackHidden = params.step === '1' || pathname === ROUTES.ON_BOARDING_FINAL();
 
   const handleBackClick = () => {
     const currentStep = Number(params.step);
 
     if (!Number.isFinite(currentStep) || currentStep <= 1) {
-      router.push(ROUTES.ON_BOARDING(1));
+      router.push(ROUTES.ON_BOARDING(1, returnToParams));
       return;
     }
 
-    router.push(ROUTES.ON_BOARDING(currentStep - 1));
+    router.push(ROUTES.ON_BOARDING(currentStep - 1, returnToParams));
   };
 
   return (

--- a/apps/web/src/app/(auth)/on-boarding/components/client-navigation/ClientNavigation.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/components/client-navigation/ClientNavigation.tsx
@@ -3,7 +3,7 @@
 import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { IconArrowBack } from '@snappin/design-system/assets';
 import { Navigation } from '@snappin/design-system';
-import { buildReturnToParams, readReturnToContext } from '@/auth/utils/returnTo';
+import { getReturnToParam, readReturnToContext } from '@/auth/utils/returnTo';
 import { ROUTES } from '@/constants/routes/routes';
 
 export default function ClientNavigation() {
@@ -11,7 +11,7 @@ export default function ClientNavigation() {
   const pathname = usePathname();
   const params = useParams<{ step?: string }>();
   const searchParams = useSearchParams();
-  const returnToParams = buildReturnToParams(readReturnToContext(searchParams));
+  const returnToParams = getReturnToParam(readReturnToContext(searchParams));
 
   const isBackHidden = params.step === '1' || pathname === ROUTES.ON_BOARDING_FINAL();
 

--- a/apps/web/src/app/(auth)/on-boarding/final/components/client-footer/ClientFooter.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/final/components/client-footer/ClientFooter.tsx
@@ -1,20 +1,24 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { BottomCTAButton } from '@snappin/design-system';
+import { readReturnToContext, resolveReturnToPath } from '@/auth/utils/returnTo';
 import { ROUTES } from '@/constants/routes/routes';
 
 export default function ClientFooter() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const returnToContext = readReturnToContext(searchParams);
+  const buttonLabel = returnToContext.returnTo ? '이전 화면으로 가기' : '홈으로 가기';
 
   const handleClick = () => {
-    router.push(ROUTES.HOME);
+    router.push(resolveReturnToPath(returnToContext, ROUTES.HOME));
   };
 
   return (
     <BottomCTAButton fixed className='px-[2.7rem] pb-[2.8rem]'>
       <BottomCTAButton.Single color='black' size='large' onClick={handleClick}>
-        홈으로 가기
+        {buttonLabel}
       </BottomCTAButton.Single>
     </BottomCTAButton>
   );

--- a/apps/web/src/app/(auth)/on-boarding/final/components/client-footer/ClientFooter.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/final/components/client-footer/ClientFooter.tsx
@@ -1,18 +1,20 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { BottomCTAButton } from '@snappin/design-system';
-import { readReturnToContext, resolveReturnToPath } from '@/auth/utils/returnTo';
+import { resolveReturnToPath } from '@/auth/utils/returnTo';
 import { ROUTES } from '@/constants/routes/routes';
 
-export default function ClientFooter() {
+type ClientFooterProps = {
+  returnTo?: string;
+};
+export default function ClientFooter({ returnTo }: ClientFooterProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const returnToContext = readReturnToContext(searchParams);
-  const buttonLabel = returnToContext.returnTo ? '이전 화면으로 가기' : '홈으로 가기';
+
+  const buttonLabel = returnTo ? '이전 화면으로 가기' : '홈으로 가기';
 
   const handleClick = () => {
-    router.push(resolveReturnToPath(returnToContext, ROUTES.HOME));
+    router.push(resolveReturnToPath({ returnTo }, ROUTES.HOME));
   };
 
   return (

--- a/apps/web/src/app/(auth)/on-boarding/final/page.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/final/page.tsx
@@ -1,7 +1,20 @@
 import { GraphicSuccess } from '@snappin/design-system/assets';
 import ClientFooter from '@/app/(auth)/on-boarding/final/components/client-footer/ClientFooter';
+import { readReturnToContext } from '@/auth/utils/returnTo';
 
-export default function Page() {
+type PageProps = {
+  searchParams: Promise<{
+    returnTo?: string;
+  }>;
+};
+export default async function Page({ searchParams }: PageProps) {
+  const { returnTo: rawReturnTo } = await searchParams;
+  const returnTo = readReturnToContext(
+    new URLSearchParams({
+      returnTo: rawReturnTo ?? '',
+    }),
+  ).returnTo;
+
   return (
     <div className='flex h-full flex-col items-center justify-center gap-[1.4rem]'>
       <GraphicSuccess />
@@ -9,7 +22,8 @@ export default function Page() {
         <h1 className='title-20-sb'>가입이 완료되었어요!</h1>
         <p className='caption-14-rg text-black-7'>홈에서 다양한 무드의 스냅을 탐색해보세요</p>
       </div>
-      <ClientFooter />
+
+      <ClientFooter returnTo={returnTo} />
     </div>
   );
 }

--- a/apps/web/src/app/(auth)/on-boarding/layout.tsx
+++ b/apps/web/src/app/(auth)/on-boarding/layout.tsx
@@ -1,12 +1,15 @@
-import type { ReactNode } from 'react';
+import { Suspense, type ReactNode } from 'react';
 import ClientNavigation from '@/app/(auth)/on-boarding/components/client-navigation/ClientNavigation';
 import { OnBoardingFormProvider } from '@/app/(auth)/on-boarding/hooks/useOnBoardingFormContext';
+import { Navigation } from '@snappin/design-system';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <OnBoardingFormProvider>
       <div className='flex h-dvh w-full flex-col'>
-        <ClientNavigation />
+        <Suspense fallback={<Navigation isFixed={true} />}>
+          <ClientNavigation />
+        </Suspense>
         {children}
       </div>
     </OnBoardingFormProvider>

--- a/apps/web/src/app/(with-layout)/(home)/components/ai-curation-button/AiCurationButton.tsx
+++ b/apps/web/src/app/(with-layout)/(home)/components/ai-curation-button/AiCurationButton.tsx
@@ -1,13 +1,23 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
 import { Button } from '@snappin/design-system';
 import { cn } from '@snappin/design-system/lib';
-
+import { ROUTES } from '@/constants/routes/routes';
 type AiCurationButtonProps = {
   className?: string;
 };
 
 export default function AiCurationButton({ className }: AiCurationButtonProps) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push(ROUTES.AI_CURATION);
+  };
+
   return (
     <Button
+      onClick={handleClick}
       color='primary'
       size='large'
       className={cn('font-16-sb rounded-[4.6rem] px-[2.4rem] py-[1.3rem]', className)}

--- a/apps/web/src/app/product/[id]/components/footer/Footer.tsx
+++ b/apps/web/src/app/product/[id]/components/footer/Footer.tsx
@@ -45,6 +45,7 @@ export default function Footer({ productId, contact, amount }: FooterProps) {
       return;
     }
     // TODO: 온보딩 미완 -> 모달 띄우기 (온보딩 이동 모달 디자인 기다리는 중)
+    router.push(ROUTES.ON_BOARDING(1, { returnTo: ROUTES.PRODUCT(productId) }));
     // TODO: 온보딩 완료 -> 예약 양식 페이지로 이동
     setIsOpen(true);
   };
@@ -67,11 +68,7 @@ export default function Footer({ productId, contact, amount }: FooterProps) {
             </Button>
           }
           rightButton={
-            <Button
-              color='black'
-              size='medium'
-              onClick={handleOpenDrawer}
-            >
+            <Button color='black' size='medium' onClick={handleOpenDrawer}>
               예약 문의 작성
             </Button>
           }

--- a/apps/web/src/auth/utils/returnTo.ts
+++ b/apps/web/src/auth/utils/returnTo.ts
@@ -22,4 +22,4 @@ export const getReturnToParam = (context: ReturnToContext) =>
   context.returnTo ? { returnTo: context.returnTo } : undefined;
 
 export const resolveReturnToPath = (context: ReturnToContext, fallbackPath: string) =>
-  normalizeInternalReturnTo(context.returnTo) ?? fallbackPath;
+  context.returnTo ?? fallbackPath;

--- a/apps/web/src/auth/utils/returnTo.ts
+++ b/apps/web/src/auth/utils/returnTo.ts
@@ -1,0 +1,42 @@
+export type ReturnToContext = {
+  returnTo?: string;
+};
+
+type SearchParamReader = {
+  get(name: string): string | null;
+};
+
+const normalizeInternalReturnTo = (value: string | null | undefined) => {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) {
+    return undefined;
+  }
+
+  return value;
+};
+
+export const readReturnToContext = (params: SearchParamReader): ReturnToContext => ({
+  returnTo: normalizeInternalReturnTo(params.get('returnTo')),
+});
+
+export const buildReturnToParams = (context: ReturnToContext) => {
+  if (!context.returnTo) {
+    return undefined;
+  }
+
+  return { returnTo: context.returnTo };
+};
+
+export const serializeReturnToState = (context: ReturnToContext) => {
+  const params = buildReturnToParams(context);
+
+  return params ? new URLSearchParams(params).toString() : '';
+};
+
+export const parseReturnToState = (state: string | null) => {
+  if (!state) return {};
+
+  return readReturnToContext(new URLSearchParams(state));
+};
+
+export const resolveReturnToPath = (context: ReturnToContext, fallbackPath: string) =>
+  normalizeInternalReturnTo(context.returnTo) ?? fallbackPath;

--- a/apps/web/src/auth/utils/returnTo.ts
+++ b/apps/web/src/auth/utils/returnTo.ts
@@ -18,25 +18,8 @@ export const readReturnToContext = (params: SearchParamReader): ReturnToContext 
   returnTo: normalizeInternalReturnTo(params.get('returnTo')),
 });
 
-export const buildReturnToParams = (context: ReturnToContext) => {
-  if (!context.returnTo) {
-    return undefined;
-  }
-
-  return { returnTo: context.returnTo };
-};
-
-export const serializeReturnToState = (context: ReturnToContext) => {
-  const params = buildReturnToParams(context);
-
-  return params ? new URLSearchParams(params).toString() : '';
-};
-
-export const parseReturnToState = (state: string | null) => {
-  if (!state) return {};
-
-  return readReturnToContext(new URLSearchParams(state));
-};
+export const getReturnToParam = (context: ReturnToContext) =>
+  context.returnTo ? { returnTo: context.returnTo } : undefined;
 
 export const resolveReturnToPath = (context: ReturnToContext, fallbackPath: string) =>
   normalizeInternalReturnTo(context.returnTo) ?? fallbackPath;

--- a/apps/web/src/constants/routes/routes.ts
+++ b/apps/web/src/constants/routes/routes.ts
@@ -6,8 +6,9 @@ export const ROUTES = {
   AI_CURATION: '/ai-curation',
   AI_CURATION_STEP: (step: number) => `/ai-curation/${step}`,
   AI_CURATION_RESULT: '/ai-curation/result',
-  ON_BOARDING: (step: number) => `/on-boarding/${step}`,
-  ON_BOARDING_FINAL: '/on-boarding/final',
+  ON_BOARDING: (step: number, params?: Params) =>
+    `/on-boarding/${step}${params ? getQueryParams(params) : ''}`,
+  ON_BOARDING_FINAL: (params?: Params) => `/on-boarding/final${params ? getQueryParams(params) : ''}`,
   EXPLORE: (params?: Params) => `/explore${params ? getQueryParams(params) : ''}`,
   LIKE: '/like',
   PROFILE: '/profile',

--- a/apps/web/src/query-key/auth.ts
+++ b/apps/web/src/query-key/auth.ts
@@ -1,8 +1,9 @@
 export const AUTH_QUERY_KEY = {
   AUTH: ['auth'],
+  // 온보딩
   ONBOARDING: () => [...AUTH_QUERY_KEY.AUTH, 'onboarding'],
   // AI 큐레이션
-  AI_CURATION: ['ai-curation'],
-  AI_CURATION_ALL: () => [...AUTH_QUERY_KEY.AUTH, 'all'],
-  AI_CURATION_RESULT: () => [...AUTH_QUERY_KEY.AUTH, 'result'],
+  AI_CURATION: () => [...AUTH_QUERY_KEY.AUTH, 'ai-curation'],
+  AI_CURATION_ALL: () => [...AUTH_QUERY_KEY.AI_CURATION(), 'all'],
+  AI_CURATION_RESULT: () => [...AUTH_QUERY_KEY.AI_CURATION(), 'result'],
 };

--- a/apps/web/src/query-key/auth.ts
+++ b/apps/web/src/query-key/auth.ts
@@ -1,3 +1,4 @@
 export const AUTH_QUERY_KEY = {
   AUTH: ['auth'],
+  ONBOARDING: () => [...AUTH_QUERY_KEY.AUTH, 'onboarding'],
 };

--- a/apps/web/src/query-key/auth.ts
+++ b/apps/web/src/query-key/auth.ts
@@ -1,4 +1,8 @@
 export const AUTH_QUERY_KEY = {
   AUTH: ['auth'],
   ONBOARDING: () => [...AUTH_QUERY_KEY.AUTH, 'onboarding'],
+  // AI 큐레이션
+  AI_CURATION: ['ai-curation'],
+  AI_CURATION_ALL: () => [...AUTH_QUERY_KEY.AUTH, 'all'],
+  AI_CURATION_RESULT: () => [...AUTH_QUERY_KEY.AUTH, 'result'],
 };

--- a/apps/web/src/query-key/user.ts
+++ b/apps/web/src/query-key/user.ts
@@ -1,9 +1,4 @@
 export const USER_QUERY_KEY = {
-  // AI 큐레이션
-  AI_CURATION: ['ai-curation'],
-  AI_CURATION_ALL: () => [...USER_QUERY_KEY.AI_CURATION, 'all'],
-  AI_CURATION_RESULT: () => [...USER_QUERY_KEY.AI_CURATION, 'result'],
-
   // 추천 스냅 명소
   RECOMMENDATION: ['recommendation'],
   RECOMMENDATION_SNAP_PLACE: () => [...USER_QUERY_KEY.RECOMMENDATION, 'places'],

--- a/packages/design-system/src/ui/input/base/Input.tsx
+++ b/packages/design-system/src/ui/input/base/Input.tsx
@@ -11,10 +11,7 @@ export default function Input({ hasError, hasBorder = true, className, ...props 
       className={cn(
         'bg-black-1 caption-14-md border-black-10 placeholder:text-black-6 w-full border-b px-[0.7rem] py-[1.2rem]',
         hasBorder && 'border-black-5 focus:border-black-10 rounded-[0.6rem] border',
-        hasError &&
-          (hasBorder
-            ? 'border-red-500 focus:border-red-500 focus:ring-red-200'
-            : 'text-red-500 placeholder:text-red-300'),
+        hasError && hasBorder && 'border-red-500 focus:border-red-500 focus:ring-red-200',
         className,
       )}
       {...props}


### PR DESCRIPTION
## 📌 Related Issues

<!-- 관련 이슈를 작성해주세요 -->

- close #420 

## 🗯️ 체크 리스트

- [ ] PR 제목을 규칙에 맞게 작성했나요?  
       EX: 🎀 Feat (design-system) : #이슈번호 PR 내용
- [ ] 빌드가 성공했나요? (`pnpm build`)

## 🛠️ Tasks

<!-- 작업한 내용을 작성해주세요 -->

- 로그인 API 연동
- 온보딩 API 연동
- AI 무드 큐레이션 API 연동

## 👀 PR Point (To Reviewer)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 온보딩 완료 x 라면 -> 온보딩 -> 이전 페이지로 복귀 로직(auth/utils/returnTo.ts)


1. 로그인 후 온보딩이 필요한 경우
특정 페이지에서 로그인/온보딩으로 진입해도 returnTo를 유지해서, 온보딩 완료 후 원래 보던 페이지로 복귀하도록 정리했습니다. 
기존처럼 온보딩 완료 후 무조건 홈으로 보내지 않고, 로그인 페이지, 로그인 콜백, 온보딩 step/final 전 구간에서 returnTo를 전달합니다.

2. 이미 온보딩이 끝난 경우

- returnTo가 있으면 그 경로로 이동
- returnTo가 없고 PHOTOGRAPHER면 작가 예약 페이지로 이동
- 그 외에는 홈으로 이동

3. 상품 상세에서 온보딩에 진입하는 경우
상품 상세에서온보딩이 필요한 사용자는 returnTo에 상품 상세 경로를 담아요.
그러면 온보딩 완료 후 다시 동일한 상품 상세 페이지로 복귀할 수 있어요.

#### 코드 설명

ReturnToContext = 복귀 경로를 담는 타입입니다
`{ returnTo: '/product/12' }`

readReturnToContext = 현재 URL의 returnTo 쿼리 파라미터 값을 읽고 검증합니다

getReturnToParam = returnTo가 있으면 { returnTo: '...' } / 없으면 undefined -> 읽은 복귀 경로를 다음 페이지 URL에도 계속 전달하는 용도입니다

resolveReturnToPath = 마지막에 실제 어디로 보낼지 결정합니다. returnTo가 유효하면 그 경로를 사용하고 없으면 인자로 전달된 fallback 경로를 씁니다

#### 로그인 로직

1. 현재 로그인 페이지 URL에서 returnTo를 읽음 : readReturnToContext(searchParams)
2. returnTo가 있으면 state 문자열로 직렬화
3. 카카오 authorize URL에 state로 붙여서 이동


#### 카카오 콜백 로직

1. 쿼리에서 code, error, state를 읽음

> code: 카카오 인증 성공 시 받은 인가 코드
> error: 카카오 로그인 실패 시 값
> state: 로그인 시작 전에 실어 보낸 returnTo

2. state에서 returnTo 복원
3. 에러가 있으면 로그인 페이지로 다시 이동
4. code가 있으면 서버 로그인 API 호출

> access token 저장
> user role 저장

5. 로그인 성공 후 분기

> 온보딩 미완료: /on-boarding/1?returnTo=... 로 이동
> 온보딩 완료 + returnTo 있음: 그 경로로 바로 이동
> 온보딩 완료 + returnTo 없음: 작가면 예약 페이지/ 일반 유저면 홈

### 여기서 문제
toast login을 띄울 때 로그인 후 무조건 home으로 이동이라 이거 연동 다 끝내고 수정해야함!

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

## 🔔 ETC

<!-- 기타 참고 사항을 작성해주세요 -->
