### PR TITLE
:ribbon: Feat(web) : #418 explore api v2 연결

### DIFF
--- a/apps/web/src/app/(with-layout)/explore/_section/PortfolioListSection.tsx
+++ b/apps/web/src/app/(with-layout)/explore/_section/PortfolioListSection.tsx
@@ -6,6 +6,7 @@ import { GetPortfolioCardResponseV2 } from '@/swagger-api';
 import { useGetPortfolioList } from '@/app/(with-layout)/explore/api';
 import { useInfiniteScroll } from '@/app/(with-layout)/explore/hooks/use-infinite-scroll';
 import { toExploreSearchParams } from '@/app/(with-layout)/explore/utils/query';
+import { useAuth } from '@/auth/hooks/useAuth';
 import { useScrollRestoreOnParent } from '@/hooks/useScrollRestoreOnParent';
 import type { PortfolioFrameProps } from '@/ui/frame/portfolio/PortfolioFrame';
 import PortfolioList from '@/ui/frame/portfolio/PortfolioList';
@@ -27,9 +28,23 @@ const toPortfolioFrameProps = (
 };
 
 export default function PortfolioListSection() {
+  const { isLogIn } = useAuth();
   const sp = useSearchParams();
+
+  if (isLogIn === null) return null;
+
+  return <PortfolioListSectionContent isLogIn={isLogIn} searchParams={sp.toString()} />;
+}
+
+function PortfolioListSectionContent({
+  isLogIn,
+  searchParams,
+}: {
+  isLogIn: boolean;
+  searchParams: string;
+}) {
   const scrollKey = useMemo(() => {
-    const allowed = toExploreSearchParams(new URLSearchParams(sp.toString()));
+    const allowed = toExploreSearchParams(new URLSearchParams(searchParams));
 
     allowed.delete('tab');
 
@@ -38,8 +53,8 @@ export default function PortfolioListSection() {
     allowed.forEach((value, key) => normalized.append(key, value));
 
     return `explore:portfolio:scroll?${normalized.toString()}`;
-  }, [sp]);
-  const query = useGetPortfolioList(new URLSearchParams(sp.toString()));
+  }, [searchParams]);
+  const query = useGetPortfolioList(new URLSearchParams(searchParams), isLogIn);
   const portfolios = useMemo(() => {
     return query.data.pages.flatMap((page) => page.data?.portfolios ?? []);
   }, [query.data.pages]);

--- a/apps/web/src/app/(with-layout)/explore/_section/PortfolioListSection.tsx
+++ b/apps/web/src/app/(with-layout)/explore/_section/PortfolioListSection.tsx
@@ -1,46 +1,49 @@
 'use client';
 
-import { PORTFOLIO_MOCK } from '@/app/product/[id]/mocks/mock';
+import { useSearchParams } from 'next/navigation';
+import { useMemo, useRef } from 'react';
+import { GetPortfolioCardResponseV2 } from '@/swagger-api';
+import { useGetPortfolioList } from '@/app/(with-layout)/explore/api';
+import { useInfiniteScroll } from '@/app/(with-layout)/explore/hooks/use-infinite-scroll';
+import { toExploreSearchParams } from '@/app/(with-layout)/explore/utils/query';
+import { useScrollRestoreOnParent } from '@/hooks/useScrollRestoreOnParent';
 import type { PortfolioFrameProps } from '@/ui/frame/portfolio/PortfolioFrame';
 import PortfolioList from '@/ui/frame/portfolio/PortfolioList';
-/*import { useSearchParams } from 'next/navigation';*/
-/*import { useMemo, useRef } from 'react';
-import { useScrollRestoreOnParent } from '@/hooks/useScrollRestoreOnParent';
-import { toExploreSearchParams } from '@/app/(with-layout)/explore/utils/query';
-import { useInfiniteScroll } from '@/app/(with-layout)/explore/hooks/use-infinite-scroll';
-import { useGetPortfolioList } from '@/app/(with-layout)/explore/api';*/
 
 const toPortfolioFrameProps = (
-  portfolios: typeof PORTFOLIO_MOCK.portfolios = [],
+  portfolios: GetPortfolioCardResponseV2[] = [],
 ): PortfolioFrameProps[] => {
-  return portfolios.map(({ imageUrl, ...portfolio }) => ({
-    ...portfolio,
-    image: {
-      src: imageUrl,
-      alt: `포트폴리오 이미지 ${portfolio.id}`,
-    },
-  }));
+  return portfolios
+    .filter((portfolio): portfolio is GetPortfolioCardResponseV2 & { id: number } => portfolio.id != null)
+    .map((portfolio) => ({
+      id: portfolio.id,
+      isLiked: portfolio.isLiked ?? false,
+      likesCount: portfolio.likeCount ?? 0,
+      image: {
+        src: portfolio.imageUrl || '/imgs/default-image.png',
+        alt: `포트폴리오 이미지 ${portfolio.id}`,
+      },
+    }));
 };
 
 export default function PortfolioListSection() {
-  /*const sp = useSearchParams();*/
-  /*const scrollKey = useMemo(() => {
+  const sp = useSearchParams();
+  const scrollKey = useMemo(() => {
     const allowed = toExploreSearchParams(new URLSearchParams(sp.toString()));
-    // 키 순서를 완전히 고정해 같은 조건이면 항상 동일한 storage key를 만든다.
+
     allowed.delete('tab');
+
     const normalized = new URLSearchParams();
     normalized.set('tab', 'PORTFOLIO');
     allowed.forEach((value, key) => normalized.append(key, value));
+
     return `explore:portfolio:scroll?${normalized.toString()}`;
-  }, [sp]);*/
-  const portfolioList = toPortfolioFrameProps(PORTFOLIO_MOCK.portfolios);
-
-  /*const query = useGetPortfolioList(new URLSearchParams(sp.toString()));
-
+  }, [sp]);
+  const query = useGetPortfolioList(new URLSearchParams(sp.toString()));
   const portfolios = useMemo(() => {
     return query.data.pages.flatMap((page) => page.data?.portfolios ?? []);
   }, [query.data.pages]);
-
+  const portfolioList = toPortfolioFrameProps(portfolios);
   const { sentinelRef } = useInfiniteScroll({
     enabled: true,
     hasNextPage: query.hasNextPage,
@@ -48,30 +51,26 @@ export default function PortfolioListSection() {
     onLoadMore: query.fetchNextPage,
   });
   const anchorRef = useRef<HTMLDivElement | null>(null);
+
   useScrollRestoreOnParent(anchorRef, scrollKey, [portfolios.length, query.dataUpdatedAt], {
     enabled: true,
     resetOnKeyChange: true,
   });
-*/
-  const isPortfolioListEmpty = portfolioList.length === 0;
-  console.log('portfolioList', portfolioList);
 
-  if (isPortfolioListEmpty)
+  if (portfolioList.length === 0) {
     return (
       <section className='bg-black-1 flex min-h-[calc(100vh-29.9rem)] flex-1 flex-col items-center justify-center gap-[0.4rem]'>
         <h3 className='font-18-bd text-black-9'>검색 결과가 없어요</h3>
         <span className='caption-14-md text-black-6 mt-[0.8rem]'>다른 키워드로 검색해보세요</span>
       </section>
     );
+  }
 
   return (
     <section className='py-[0.2rem]'>
-      {/*<div ref={anchorRef} />*/}
+      <div ref={anchorRef} />
       <PortfolioList portfolios={portfolioList} />
-
-      {/*<div ref={sentinelRef} className='h-[1px]' />*/}
-
-      {/*{query.isFetchingNextPage ? <PortfolioListSkeleton length={3} /> : null}*/}
+      <div ref={sentinelRef} className='h-[1px]' />
     </section>
   );
 }

--- a/apps/web/src/app/(with-layout)/explore/_section/ProductListSection.tsx
+++ b/apps/web/src/app/(with-layout)/explore/_section/ProductListSection.tsx
@@ -1,75 +1,81 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
+import { useMemo, useRef } from 'react';
+import { GetProductCardResponseV2 } from '@/swagger-api';
+import { useGetProductList } from '@/app/(with-layout)/explore/api';
+import { useInfiniteScroll } from '@/app/(with-layout)/explore/hooks/use-infinite-scroll';
+import { toExploreSearchParams } from '@/app/(with-layout)/explore/utils/query';
+import { useScrollRestoreOnParent } from '@/hooks/useScrollRestoreOnParent';
+import type { ProductFrameProps } from '@/ui/frame/product/ProductFrame';
 import FrameProductList from '@/ui/frame/product/ProductList';
-import { PRODUCT_LIST_MOCK } from '@/app/product/[id]/mocks/mock';
+
+const toProductFrameProps = (products: GetProductCardResponseV2[] = []): ProductFrameProps[] => {
+  return products
+    .filter((product): product is GetProductCardResponseV2 & { id: number } => product.id != null)
+    .map((product) => ({
+      id: product.id,
+      isLiked: product.isLiked ?? false,
+      image: {
+        src: product.imageUrl || '/imgs/default-image.png',
+        alt: `상품 이미지 ${product.id}`,
+      },
+      name: product.title ?? '',
+      rate: product.averageRating ?? 0,
+      reviewCount: product.reviewCount ?? 0,
+      photographer: product.photographer ?? '',
+      price: product.price ?? 0,
+      moods: product.moods ?? [],
+    }));
+};
 
 export default function ProductListSection() {
-  /* const sp = useSearchParams();
+  const sp = useSearchParams();
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, dataUpdatedAt } = useGetProductList(
     new URLSearchParams(sp.toString()),
-  );*/
-
-  /* const products = useMemo(
-    () =>
-      data.pages
-        .flatMap((p) => p.data?.products ?? [])
-        .filter((p): p is GetProductCardResponse & { id: number } => p.id != null)
-        .map((p) => ({
-          id: p.id,
-          photographer: p.photographer ?? '',
-          moods: p.moods ?? [],
-          rate: p.rate ?? 0,
-          reviewCount: p.reviewCount ?? 0,
-          price: p.price ?? 0,
-          title: p.title ?? '',
-            imageUrl: p.imageUrl ?? '',
-        })),
-    [data.pages],
-  );*/
-  const products = PRODUCT_LIST_MOCK;
-
-  /* const { sentinelRef } = useInfiniteScroll({
+  );
+  const products = useMemo(() => {
+    return data.pages.flatMap((page) => page.data?.products ?? []);
+  }, [data.pages]);
+  const productList = toProductFrameProps(products);
+  const { sentinelRef } = useInfiniteScroll({
     enabled: true,
     hasNextPage,
     isFetchingNextPage,
-    onLoadMore: () => fetchNextPage(),
-  });*/
-
-  /* const scrollKey = useMemo(() => {
+    onLoadMore: fetchNextPage,
+  });
+  const scrollKey = useMemo(() => {
     const allowed = toExploreSearchParams(new URLSearchParams(sp.toString()));
+
     allowed.delete('tab');
+
     const normalized = new URLSearchParams();
     normalized.set('tab', 'PRODUCT');
     allowed.forEach((value, key) => normalized.append(key, value));
-    return `explore:product:scroll?${normalized.toString()}`;
-  }, [sp]);*/
 
-  /* const anchorRef = useRef<HTMLDivElement | null>(null);
-  useScrollRestoreOnParent(anchorRef, scrollKey, [products.length, dataUpdatedAt], {
+    return `explore:product:scroll?${normalized.toString()}`;
+  }, [sp]);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+
+  useScrollRestoreOnParent(anchorRef, scrollKey, [productList.length, dataUpdatedAt], {
     enabled: true,
     resetOnKeyChange: true,
-  });*/
+  });
 
-  const isProductListEmpty = products.length === 0;
-
-  if (isProductListEmpty)
+  if (productList.length === 0) {
     return (
       <section className='flex min-h-[calc(100vh-29.9rem)] flex-col items-center justify-center gap-[0.4rem]'>
         <h3 className='font-18-bd text-black-9'>검색 결과가 없어요</h3>
         <span className='caption-14-md text-black-6 mt-[0.8rem]'>다른 키워드로 검색해보세요</span>
       </section>
     );
+  }
 
   return (
     <section>
-      {/*<div ref={anchorRef} />
-      <ProductList
-        productList={products}
-        className='bg-black-1 grid grid-cols-2 gap-x-[0.3rem] gap-y-[1.2rem]'
-      />
+      <div ref={anchorRef} />
+      <FrameProductList products={productList} />
       <div ref={sentinelRef} className='h-[1px]' />
-      {isFetchingNextPage && <ProductListSkeleton length={3} />}*/}
-      <FrameProductList products={products} />
     </section>
   );
 }

--- a/apps/web/src/app/(with-layout)/explore/_section/ProductListSection.tsx
+++ b/apps/web/src/app/(with-layout)/explore/_section/ProductListSection.tsx
@@ -6,6 +6,7 @@ import { GetProductCardResponseV2 } from '@/swagger-api';
 import { useGetProductList } from '@/app/(with-layout)/explore/api';
 import { useInfiniteScroll } from '@/app/(with-layout)/explore/hooks/use-infinite-scroll';
 import { toExploreSearchParams } from '@/app/(with-layout)/explore/utils/query';
+import { useAuth } from '@/auth/hooks/useAuth';
 import { useScrollRestoreOnParent } from '@/hooks/useScrollRestoreOnParent';
 import type { ProductFrameProps } from '@/ui/frame/product/ProductFrame';
 import FrameProductList from '@/ui/frame/product/ProductList';
@@ -30,9 +31,24 @@ const toProductFrameProps = (products: GetProductCardResponseV2[] = []): Product
 };
 
 export default function ProductListSection() {
+  const { isLogIn } = useAuth();
   const sp = useSearchParams();
+
+  if (isLogIn === null) return null;
+
+  return <ProductListSectionContent isLogIn={isLogIn} searchParams={sp.toString()} />;
+}
+
+function ProductListSectionContent({
+  isLogIn,
+  searchParams,
+}: {
+  isLogIn: boolean;
+  searchParams: string;
+}) {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, dataUpdatedAt } = useGetProductList(
-    new URLSearchParams(sp.toString()),
+    new URLSearchParams(searchParams),
+    isLogIn,
   );
   const products = useMemo(() => {
     return data.pages.flatMap((page) => page.data?.products ?? []);
@@ -45,7 +61,7 @@ export default function ProductListSection() {
     onLoadMore: fetchNextPage,
   });
   const scrollKey = useMemo(() => {
-    const allowed = toExploreSearchParams(new URLSearchParams(sp.toString()));
+    const allowed = toExploreSearchParams(new URLSearchParams(searchParams));
 
     allowed.delete('tab');
 
@@ -54,7 +70,7 @@ export default function ProductListSection() {
     allowed.forEach((value, key) => normalized.append(key, value));
 
     return `explore:product:scroll?${normalized.toString()}`;
-  }, [sp]);
+  }, [searchParams]);
   const anchorRef = useRef<HTMLDivElement | null>(null);
 
   useScrollRestoreOnParent(anchorRef, scrollKey, [productList.length, dataUpdatedAt], {

--- a/apps/web/src/app/(with-layout)/explore/api/index.ts
+++ b/apps/web/src/app/(with-layout)/explore/api/index.ts
@@ -1,32 +1,31 @@
 import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
-  ApiResponseBodyGetMoodFilterListResponseVoid,
-  ApiResponseBodyGetPortfolioListResponseV2GetPortfolioMetaResponseV2,
-  ApiResponseBodyGetProductListResponseV2GetProductMetaResponseV2,
   CategoriesResponse,
+  GetAllMoodFiltersData,
   GetMoodFilterListResponse,
   GetPlaceResponse,
+  GetPortfolioListData,
+  GetProductListData,
 } from '@/swagger-api';
+import { SERVER_API_BASE_URL } from '@/api/constants/api';
 import { apiRequest } from '@/api/apiRequest';
 import { useAuth } from '@/auth/hooks/useAuth';
 import { USER_QUERY_KEY } from '@/query-key/user';
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_SERVER_BASE_URL;
-
 const CATEGORY_END_POINT = '/api/v1/categories';
-const CATEGORY_FULL_URL = BASE_URL + CATEGORY_END_POINT;
+const CATEGORY_FULL_URL = SERVER_API_BASE_URL + CATEGORY_END_POINT;
 
 const MOODS_ENDPOINT = '/api/v1/moods';
-const MOODS_FULL_URL = BASE_URL + MOODS_ENDPOINT;
+const MOODS_FULL_URL = SERVER_API_BASE_URL + MOODS_ENDPOINT;
 
 const PLACE_ENDPOINT = '/api/v1/places';
-const PLACE_FULL_URL = `${BASE_URL}${PLACE_ENDPOINT}`;
+const PLACE_FULL_URL = `${SERVER_API_BASE_URL}${PLACE_ENDPOINT}`;
 
 const PORTFOLIO_ENDPOINT = '/api/v2/portfolios';
-const PORTFOLIO_FULL_URL = `${BASE_URL}${PORTFOLIO_ENDPOINT}`;
+const PORTFOLIO_FULL_URL = `${SERVER_API_BASE_URL}${PORTFOLIO_ENDPOINT}`;
 
 const PRODUCT_ENDPOINT = '/api/v2/products';
-const PRODUCT_FULL_URL = `${BASE_URL}${PRODUCT_ENDPOINT}`;
+const PRODUCT_FULL_URL = `${SERVER_API_BASE_URL}${PRODUCT_ENDPOINT}`;
 
 export const useSearchPlaces = (keyword: string) => {
   const trimmedKeyword = keyword.trim();
@@ -95,7 +94,7 @@ export const useMoodFilters = () => {
     enabled: authResolved,
     queryFn: async () => {
       if (isLogIn) {
-        const response = await apiRequest<ApiResponseBodyGetMoodFilterListResponseVoid>({
+        const response = await apiRequest<GetAllMoodFiltersData>({
           method: 'GET',
           endPoint: MOODS_ENDPOINT,
         });
@@ -168,51 +167,67 @@ const buildExploreListQuery = (sp: URLSearchParams) => {
   return query;
 };
 
-export const useGetPortfolioList = (sp: URLSearchParams) => {
+const toRequestParams = (query: URLSearchParams) => {
+  return Object.fromEntries(query.entries());
+};
+
+export const useGetPortfolioList = (sp: URLSearchParams, isLogIn: boolean) => {
   const baseQuery = buildExploreListQuery(sp);
 
-  return useSuspenseInfiniteQuery<ApiResponseBodyGetPortfolioListResponseV2GetPortfolioMetaResponseV2>(
-    {
-      queryKey: USER_QUERY_KEY.PORTFOLIO_LIST(baseQuery.toString()),
-      staleTime: 5 * 60 * 1000,
-      gcTime: 10 * 60 * 1000,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-      refetchOnWindowFocus: false,
-      initialPageParam: undefined,
-      queryFn: async ({ pageParam }) => {
-        const url = new URL(PORTFOLIO_FULL_URL);
+  return useSuspenseInfiniteQuery<GetPortfolioListData>({
+    queryKey: USER_QUERY_KEY.PORTFOLIO_LIST(`${baseQuery.toString()}-${isLogIn ? 'login' : 'guest'}`),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+    initialPageParam: undefined,
+    queryFn: async ({ pageParam }) => {
+      const url = new URL(PORTFOLIO_FULL_URL);
 
-        baseQuery.forEach((value, key) => url.searchParams.set(key, value));
+      baseQuery.forEach((value, key) => url.searchParams.set(key, value));
 
-        if (pageParam !== undefined && pageParam !== null) {
-          url.searchParams.set('cursor', String(pageParam));
-        }
+      if (pageParam !== undefined && pageParam !== null) {
+        url.searchParams.set('cursor', String(pageParam));
+      }
 
-        const response = await fetch(url.toString(), { method: 'GET' });
-        if (!response.ok) {
-          throw new Error('/api/v2/portfolios 응답 실패');
-        }
+      if (isLogIn) {
+        const response = await apiRequest<GetPortfolioListData>({
+          endPoint: PORTFOLIO_ENDPOINT,
+          method: 'GET',
+          params: toRequestParams(url.searchParams),
+        });
 
-        const data = await response.json();
-        if (!data.data) {
+        if (!response.data) {
           throw new Error('/api/v2/portfolios 응답에 데이터가 존재하지 않습니다.');
         }
 
-        return data;
-      },
-      getNextPageParam: (lastPage) => {
-        return lastPage.meta?.hasNext ? lastPage.meta?.nextCursor : undefined;
-      },
+        return response;
+      }
+
+      const response = await fetch(url.toString(), { method: 'GET' });
+      if (!response.ok) {
+        throw new Error('/api/v2/portfolios 응답 실패');
+      }
+
+      const data = await response.json();
+      if (!data.data) {
+        throw new Error('/api/v2/portfolios 응답에 데이터가 존재하지 않습니다.');
+      }
+
+      return data;
     },
-  );
+    getNextPageParam: (lastPage) => {
+      return lastPage.meta?.hasNext ? lastPage.meta?.nextCursor : undefined;
+    },
+  });
 };
 
-export const useGetProductList = (sq: URLSearchParams) => {
-  const baseQuery = buildExploreListQuery(sq);
+export const useGetProductList = (sp: URLSearchParams, isLogIn: boolean) => {
+  const baseQuery = buildExploreListQuery(sp);
 
-  return useSuspenseInfiniteQuery<ApiResponseBodyGetProductListResponseV2GetProductMetaResponseV2>({
-    queryKey: USER_QUERY_KEY.PRODUCT_LIST(baseQuery.toString()),
+  return useSuspenseInfiniteQuery<GetProductListData>({
+    queryKey: USER_QUERY_KEY.PRODUCT_LIST(`${baseQuery.toString()}-${isLogIn ? 'login' : 'guest'}`),
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     refetchOnMount: false,
@@ -226,6 +241,20 @@ export const useGetProductList = (sq: URLSearchParams) => {
 
       if (pageParam !== undefined && pageParam !== null) {
         url.searchParams.set('cursor', String(pageParam));
+      }
+
+      if (isLogIn) {
+        const response = await apiRequest<GetProductListData>({
+          endPoint: PRODUCT_ENDPOINT,
+          method: 'GET',
+          params: toRequestParams(url.searchParams),
+        });
+
+        if (!response.data) {
+          throw new Error('/api/v2/products 응답에 데이터가 존재하지 않습니다.');
+        }
+
+        return response;
       }
 
       const response = await fetch(url.toString(), { method: 'GET' });

--- a/apps/web/src/app/(with-layout)/explore/api/index.ts
+++ b/apps/web/src/app/(with-layout)/explore/api/index.ts
@@ -152,7 +152,7 @@ export const buildExploreQuery = (sp: URLSearchParams) => {
   if (date) query.set('date', date);
 
   const peopleCount = sp.get('peopleCount');
-  if (peopleCount) query.set('peopleCount', peopleCount);
+  if (peopleCount && Number(peopleCount) > 0) query.set('peopleCount', peopleCount);
 
   return query;
 };

--- a/apps/web/src/app/(with-layout)/explore/api/index.ts
+++ b/apps/web/src/app/(with-layout)/explore/api/index.ts
@@ -2,10 +2,10 @@ import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/
 import {
   ApiResponseBodyGetMoodFilterListResponseVoid,
   ApiResponseBodyGetPortfolioListResponseV2GetPortfolioMetaResponseV2,
+  ApiResponseBodyGetProductListResponseV2GetProductMetaResponseV2,
   CategoriesResponse,
   GetMoodFilterListResponse,
   GetPlaceResponse,
-  GetProductListData,
 } from '@/swagger-api';
 import { apiRequest } from '@/api/apiRequest';
 import { useAuth } from '@/auth/hooks/useAuth';
@@ -25,7 +25,7 @@ const PLACE_FULL_URL = `${BASE_URL}${PLACE_ENDPOINT}`;
 const PORTFOLIO_ENDPOINT = '/api/v2/portfolios';
 const PORTFOLIO_FULL_URL = `${BASE_URL}${PORTFOLIO_ENDPOINT}`;
 
-const PRODUCT_ENDPOINT = '/api/v1/products';
+const PRODUCT_ENDPOINT = '/api/v2/products';
 const PRODUCT_FULL_URL = `${BASE_URL}${PRODUCT_ENDPOINT}`;
 
 export const useSearchPlaces = (keyword: string) => {
@@ -157,7 +157,7 @@ export const buildExploreQuery = (sp: URLSearchParams) => {
   return query;
 };
 
-const buildExplorePortfolioQuery = (sp: URLSearchParams) => {
+const buildExploreListQuery = (sp: URLSearchParams) => {
   const query = buildExploreQuery(sp);
   const sort = sp.get('sort');
 
@@ -169,7 +169,7 @@ const buildExplorePortfolioQuery = (sp: URLSearchParams) => {
 };
 
 export const useGetPortfolioList = (sp: URLSearchParams) => {
-  const baseQuery = buildExplorePortfolioQuery(sp);
+  const baseQuery = buildExploreListQuery(sp);
 
   return useSuspenseInfiniteQuery<ApiResponseBodyGetPortfolioListResponseV2GetPortfolioMetaResponseV2>(
     {
@@ -209,9 +209,9 @@ export const useGetPortfolioList = (sp: URLSearchParams) => {
 };
 
 export const useGetProductList = (sq: URLSearchParams) => {
-  const baseQuery = buildExploreQuery(sq);
+  const baseQuery = buildExploreListQuery(sq);
 
-  return useSuspenseInfiniteQuery<GetProductListData>({
+  return useSuspenseInfiniteQuery<ApiResponseBodyGetProductListResponseV2GetProductMetaResponseV2>({
     queryKey: USER_QUERY_KEY.PRODUCT_LIST(baseQuery.toString()),
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
@@ -228,10 +228,17 @@ export const useGetProductList = (sq: URLSearchParams) => {
         url.searchParams.set('cursor', String(pageParam));
       }
 
-      const res = await fetch(url.toString(), { method: 'GET' });
-      if (!res.ok) throw new Error('/api/v1/products 응답 실패');
+      const response = await fetch(url.toString(), { method: 'GET' });
+      if (!response.ok) {
+        throw new Error('/api/v2/products 응답 실패');
+      }
 
-      return await res.json();
+      const data = await response.json();
+      if (!data.data) {
+        throw new Error('/api/v2/products 응답에 데이터가 존재하지 않습니다.');
+      }
+
+      return data;
     },
     getNextPageParam: (lastPage) => {
       return lastPage.meta?.hasNext ? lastPage.meta?.nextCursor : undefined;

--- a/apps/web/src/app/(with-layout)/explore/api/index.ts
+++ b/apps/web/src/app/(with-layout)/explore/api/index.ts
@@ -1,15 +1,15 @@
 import { useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
 import {
-  GetPlaceResponse,
   ApiResponseBodyGetMoodFilterListResponseVoid,
+  ApiResponseBodyGetPortfolioListResponseV2GetPortfolioMetaResponseV2,
   CategoriesResponse,
   GetMoodFilterListResponse,
+  GetPlaceResponse,
   GetProductListData,
-  ApiResponseBodyGetPortfolioListResponseGetPortfolioMetaResponse,
 } from '@/swagger-api';
-import { USER_QUERY_KEY } from '@/query-key/user';
-import { useAuth } from '@/auth/hooks/useAuth';
 import { apiRequest } from '@/api/apiRequest';
+import { useAuth } from '@/auth/hooks/useAuth';
+import { USER_QUERY_KEY } from '@/query-key/user';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_SERVER_BASE_URL;
 
@@ -22,7 +22,7 @@ const MOODS_FULL_URL = BASE_URL + MOODS_ENDPOINT;
 const PLACE_ENDPOINT = '/api/v1/places';
 const PLACE_FULL_URL = `${BASE_URL}${PLACE_ENDPOINT}`;
 
-const PORTFOLIO_ENDPOINT = '/api/v1/portfolios';
+const PORTFOLIO_ENDPOINT = '/api/v2/portfolios';
 const PORTFOLIO_FULL_URL = `${BASE_URL}${PORTFOLIO_ENDPOINT}`;
 
 const PRODUCT_ENDPOINT = '/api/v1/products';
@@ -35,8 +35,8 @@ export const useSearchPlaces = (keyword: string) => {
     queryKey: USER_QUERY_KEY.PLACES_SEARCH(trimmedKeyword),
     queryFn: async ({ signal }) => {
       if (trimmedKeyword === '') return [];
-      const url = `${PLACE_FULL_URL}?keyword=${encodeURIComponent(trimmedKeyword)}`;
 
+      const url = `${PLACE_FULL_URL}?keyword=${encodeURIComponent(trimmedKeyword)}`;
       const response = await fetch(url, {
         method: 'GET',
         headers: {
@@ -48,12 +48,14 @@ export const useSearchPlaces = (keyword: string) => {
       if (!response.ok) {
         throw new Error(`촬영 장소 조회 API 요청 실패 ${response.status} ${response.statusText}`);
       }
+
       const data = await response.json();
 
       if (!data.data) return [];
+
       return data.data.places;
     },
-    staleTime: 30 * 1000, // 30 seconds
+    staleTime: 30 * 1000,
     retry: 0,
   });
 };
@@ -92,7 +94,6 @@ export const useMoodFilters = () => {
     queryKey: USER_QUERY_KEY.MOODS_FILTER(isLogIn ? 'user' : 'guest'),
     enabled: authResolved,
     queryFn: async () => {
-      // 로그인 상태
       if (isLogIn) {
         const response = await apiRequest<ApiResponseBodyGetMoodFilterListResponseVoid>({
           method: 'GET',
@@ -102,10 +103,10 @@ export const useMoodFilters = () => {
         if (!response.data) {
           throw new Error('무드 필터 데이터를 불러오지 못했습니다.');
         }
+
         return response.data;
       }
 
-      // 비 로그인상태
       const response = await fetch(MOODS_FULL_URL, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
@@ -126,7 +127,6 @@ export const useMoodFilters = () => {
   });
 };
 
-// 탐색 쿼리 빌더
 export const buildExploreQuery = (sp: URLSearchParams) => {
   const query = new URLSearchParams();
 
@@ -157,40 +157,57 @@ export const buildExploreQuery = (sp: URLSearchParams) => {
   return query;
 };
 
-// 포폴 목록 조회 API
-export const useGetPortfolioList = (sp: URLSearchParams) => {
-  const baseQuery = buildExploreQuery(sp);
+const buildExplorePortfolioQuery = (sp: URLSearchParams) => {
+  const query = buildExploreQuery(sp);
+  const sort = sp.get('sort');
 
-  return useSuspenseInfiniteQuery<ApiResponseBodyGetPortfolioListResponseGetPortfolioMetaResponse>({
-    queryKey: USER_QUERY_KEY.PORTFOLIO_LIST(baseQuery.toString()),
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
-    refetchOnMount: false,
-    refetchOnReconnect: false,
-    refetchOnWindowFocus: false,
-    initialPageParam: undefined,
-    queryFn: async ({ pageParam }) => {
-      const url = new URL(PORTFOLIO_FULL_URL);
+  query.set('snapCategory', 'GRADUATION');
 
-      // 필터 파라미터 주입
-      baseQuery.forEach((value, key) => url.searchParams.set(key, value));
+  if (sort) query.set('sort', sort);
 
-      // 커서
-      if (pageParam !== undefined && pageParam !== null) {
-        url.searchParams.set('cursor', String(pageParam));
-      }
-
-      const res = await fetch(url.toString(), { method: 'GET' });
-      if (!res.ok) throw new Error('/api/v1/portfolios 응답 실패');
-      return await res.json();
-    },
-    getNextPageParam: (lastPage) => {
-      return lastPage.meta?.hasNext ? lastPage.meta?.nextCursor : undefined;
-    },
-  });
+  return query;
 };
 
-// 상품 목록 조회 API
+export const useGetPortfolioList = (sp: URLSearchParams) => {
+  const baseQuery = buildExplorePortfolioQuery(sp);
+
+  return useSuspenseInfiniteQuery<ApiResponseBodyGetPortfolioListResponseV2GetPortfolioMetaResponseV2>(
+    {
+      queryKey: USER_QUERY_KEY.PORTFOLIO_LIST(baseQuery.toString()),
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      initialPageParam: undefined,
+      queryFn: async ({ pageParam }) => {
+        const url = new URL(PORTFOLIO_FULL_URL);
+
+        baseQuery.forEach((value, key) => url.searchParams.set(key, value));
+
+        if (pageParam !== undefined && pageParam !== null) {
+          url.searchParams.set('cursor', String(pageParam));
+        }
+
+        const response = await fetch(url.toString(), { method: 'GET' });
+        if (!response.ok) {
+          throw new Error('/api/v2/portfolios 응답 실패');
+        }
+
+        const data = await response.json();
+        if (!data.data) {
+          throw new Error('/api/v2/portfolios 응답에 데이터가 존재하지 않습니다.');
+        }
+
+        return data;
+      },
+      getNextPageParam: (lastPage) => {
+        return lastPage.meta?.hasNext ? lastPage.meta?.nextCursor : undefined;
+      },
+    },
+  );
+};
+
 export const useGetProductList = (sq: URLSearchParams) => {
   const baseQuery = buildExploreQuery(sq);
 
@@ -205,10 +222,8 @@ export const useGetProductList = (sq: URLSearchParams) => {
     queryFn: async ({ pageParam }) => {
       const url = new URL(PRODUCT_FULL_URL);
 
-      // 필터 파라미터 주입
       baseQuery.forEach((value, key) => url.searchParams.set(key, value));
 
-      // 커서
       if (pageParam !== undefined && pageParam !== null) {
         url.searchParams.set('cursor', String(pageParam));
       }

--- a/apps/web/src/app/(with-layout)/explore/components/header/ExploreHeader.tsx
+++ b/apps/web/src/app/(with-layout)/explore/components/header/ExploreHeader.tsx
@@ -5,7 +5,7 @@ import ExploreSearchButton from '@/app/(with-layout)/explore/components/header/E
 type ExploreHeaderProps = {
   currentTab: ExploreTab;
   headline: string;
-  supportingText: string;
+  isPlaceholder: boolean;
   searchSheetKey: string;
   portfolioTabHref: string;
   productTabHref: string;
@@ -14,7 +14,7 @@ type ExploreHeaderProps = {
 export default function ExploreHeader({
   currentTab,
   headline,
-  supportingText,
+  isPlaceholder,
   searchSheetKey,
   portfolioTabHref,
   productTabHref,
@@ -24,9 +24,8 @@ export default function ExploreHeader({
       <div className='px-[2rem] py-[1.6rem]'>
         <ExploreSearchButton
           headline={headline}
-          supportingText={supportingText}
+          isPlaceholder={isPlaceholder}
           searchSheetKey={searchSheetKey}
-          supportingTextClassName='text-black-7'
         />
       </div>
       <OptionSection

--- a/apps/web/src/app/(with-layout)/explore/components/header/ExploreSearchButton.tsx
+++ b/apps/web/src/app/(with-layout)/explore/components/header/ExploreSearchButton.tsx
@@ -5,22 +5,19 @@ import { openSearchSheet } from '@/utils/openSearchSheet';
 
 type ExploreSearchButtonProps = {
   headline: string;
-  supportingText?: string;
-  supportingTextClassName?: string;
+  isPlaceholder: boolean;
   searchSheetKey: string;
 };
 
 export default function ExploreSearchButton({
   headline,
-  supportingText,
-  supportingTextClassName,
+  isPlaceholder,
   searchSheetKey,
 }: ExploreSearchButtonProps) {
   return (
     <ButtonSearchBar
       headline={headline}
-      supportingText={supportingText}
-      supportingTextClassName={supportingTextClassName}
+      headlineClassName={isPlaceholder ? 'text-black-7' : undefined}
       onClick={() => openSearchSheet(searchSheetKey)}
     />
   );

--- a/apps/web/src/app/(with-layout)/explore/components/search-sheet/SearchSheet.tsx
+++ b/apps/web/src/app/(with-layout)/explore/components/search-sheet/SearchSheet.tsx
@@ -116,7 +116,10 @@ function SearchSheetContent({
       placeId: searchDraft.placeId || null,
       placeName: searchDraft.placeId ? placeKeyword : null,
       date: searchDraft.date ?? null,
-      peopleCount: searchDraft.peopleCount ?? null,
+      peopleCount:
+        searchDraft.peopleCount != null && searchDraft.peopleCount > 0
+          ? searchDraft.peopleCount
+          : null,
     });
 
     navigate(nextParams, { basePath: ROUTES.EXPLORE() });

--- a/apps/web/src/app/(with-layout)/explore/constants/sort.ts
+++ b/apps/web/src/app/(with-layout)/explore/constants/sort.ts
@@ -1,7 +1,7 @@
 export const EXPLORE_SORT = {
-  RECOMMENDED: 'recommended',
-  POPULAR: 'popular',
-  LATEST: 'latest',
+  RECOMMENDED: 'RECOMMENDED',
+  POPULAR: 'POPULAR',
+  LATEST: 'LATEST',
 } as const;
 
 export type ExploreSort = (typeof EXPLORE_SORT)[keyof typeof EXPLORE_SORT];

--- a/apps/web/src/app/(with-layout)/explore/page.tsx
+++ b/apps/web/src/app/(with-layout)/explore/page.tsx
@@ -16,7 +16,7 @@ type ExplorePageProps = {
 export default async function Explore({ searchParams }: ExplorePageProps) {
   const resolvedSearchParams = await searchParams;
   const initialSearchParams = toExploreSearchParams(resolvedSearchParams);
-  const { headline, supportingText } = getExploreSearchBarText(initialSearchParams);
+  const { headline, isPlaceholder } = getExploreSearchBarText(initialSearchParams);
   const initialTab = resolveExploreTab(initialSearchParams.get('tab'));
   const placeName = parseInitialDraft(initialSearchParams).placeName ?? '';
   const searchSheetKey = SEARCH_SHEET_KEY(placeName, initialSearchParams.toString());
@@ -33,7 +33,7 @@ export default async function Explore({ searchParams }: ExplorePageProps) {
       <ExploreHeader
         currentTab={initialTab}
         headline={headline}
-        supportingText={supportingText}
+        isPlaceholder={isPlaceholder}
         searchSheetKey={searchSheetKey}
         portfolioTabHref={getTabHref(EXPLORE_TAB.PORTFOLIO)}
         productTabHref={getTabHref(EXPLORE_TAB.PRODUCT)}

--- a/apps/web/src/app/(with-layout)/explore/utils/view-model.ts
+++ b/apps/web/src/app/(with-layout)/explore/utils/view-model.ts
@@ -1,15 +1,14 @@
-import { SNAP_CATEGORY } from '@/constants/categories/snap-category';
+import { INITIAL_MAX_PRICE, INITIAL_MIN_PRICE } from '../constants/price';
 import { EXPLORE_TAB, ExploreTab } from '../constants/tab';
-import { parseInitialDraft } from './query';
+import { parseInitialDraft, parsePriceRange } from './query';
 
-const formatDateDot = (raw: string | null | undefined) => {
-  if (!raw) return null;
-  return raw.replaceAll('-', '/');
-};
+const PLACEHOLDER_HEADLINE = '탐색을 시작해 보세요';
 
-const formatPeople = (count: number | null | undefined) => {
-  if (!count || count <= 0) return null;
-  return `${count}인`;
+const formatPriceSummary = (minPrice: number, maxPrice: number) => {
+  const minInManwon = minPrice / 10_000;
+  const maxInManwon = maxPrice / 10_000;
+
+  return `${minInManwon}만원 ~ ${maxInManwon}만원`;
 };
 
 export const resolveExploreTab = (
@@ -21,24 +20,25 @@ export const resolveExploreTab = (
 };
 
 export const getExploreSearchBarText = (sp: URLSearchParams) => {
-  const { snapCategory, placeName, date, peopleCount } = parseInitialDraft(sp);
-  const snapCategoryLabel = SNAP_CATEGORY[snapCategory as keyof typeof SNAP_CATEGORY] ?? null;
+  const { placeName } = parseInitialDraft(sp);
+  const [minPrice, maxPrice] = parsePriceRange(sp);
   const normalizedPlaceName = placeName?.trim() ? placeName.trim() : null;
-  const formattedDate = formatDateDot(date);
-  const formattedPeople = formatPeople(peopleCount);
+  const hasCustomPriceRange =
+    minPrice !== INITIAL_MIN_PRICE || maxPrice !== INITIAL_MAX_PRICE;
+  const priceSummary = hasCustomPriceRange ? formatPriceSummary(minPrice, maxPrice) : null;
+  const headlineParts = [normalizedPlaceName, priceSummary].filter(
+    (value): value is string => Boolean(value),
+  );
 
-  const isAllEmpty =
-    !snapCategoryLabel && !normalizedPlaceName && !formattedDate && !formattedPeople;
-
-  if (isAllEmpty) {
+  if (headlineParts.length === 0) {
     return {
-      headline: '어떤 스냅 작가를 찾고 있나요?',
-      supportingText: '날짜, 스냅 종류, 지역 기반으로 정교한 검색',
+      headline: PLACEHOLDER_HEADLINE,
+      isPlaceholder: true,
     };
   }
 
   return {
-    headline: `${snapCategoryLabel ?? '전체 스냅'}, ${normalizedPlaceName ?? '전체 장소'}`,
-    supportingText: `${formattedDate ?? '전체 날짜'}, ${formattedPeople ?? '전체 인원'}`,
+    headline: headlineParts.join(', '),
+    isPlaceholder: false,
   };
 };

--- a/packages/design-system/src/ui/button/button-search-bar/ButtonSearchBar.tsx
+++ b/packages/design-system/src/ui/button/button-search-bar/ButtonSearchBar.tsx
@@ -13,11 +13,9 @@ type ButtonSearchBarProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 
 export default function ButtonSearchBar({
   className,
   headline,
-  supportingText,
   type = 'button',
   iconClassName,
   headlineClassName,
-  supportingTextClassName,
   ...props
 }: ButtonSearchBarProps) {
   return (
@@ -34,17 +32,17 @@ export default function ButtonSearchBar({
         aria-hidden='true'
       />
       <span className='flex min-w-0 flex-1 flex-col gap-[0.4rem]'>
-        <span className={cn('font-16-md text-black-9', headlineClassName)} data-slot='headline'>
+        <span className={cn('caption-14-md text-black-9', headlineClassName)} data-slot='headline'>
           {headline}
         </span>
-        {supportingText ? (
+        {/*{supportingText ? (
           <span
             className={cn('caption-12-md text-black-5', supportingTextClassName)}
             data-slot='supporting'
           >
             {supportingText}
           </span>
-        ) : null}
+        ) : null}*/}
       </span>
     </button>
   );


### PR DESCRIPTION
## 📌 Related Issues

<!-- 관련 이슈를 작성해주세요 -->

- close #418 

## 🗯️ 체크 리스트

- [x] PR 제목을 규칙에 맞게 작성했나요?  
       EX: 🎀 Feat (design-system) : #이슈번호 PR 내용
- [x] 빌드가 성공했나요? (`pnpm build`)

## 🛠️ Tasks

explore 포트폴리오 목록 API를 `/api/v2/portfolios` 기준으로 변경 및 explore 상품 목록 API를 `/api/v2/products` 기준으로 변경했습니다.

포트폴리오/상품 목록 요청 시 `snapCategory`가 항상 `GRADUATION`으로 전달되도록 수정하고, 정렬 값 또한 v2 스펙(`RECOMMENDED`, `POPULAR`, `LATEST`)에 맞게 수정했습니다.

마지막으로 검색 요약 문구를 요구사항에 맞게 장소, 가격만 headline 1줄로 노출되도록 수정하고 검색 조건 미선택 시 placeholder headline 스타일이 적용되도록 수정 작업 완료했습니다.

## 👀 PR Point (To Reviewer)

- explore 목록 API가 v1에서 v2로 전환되면서 응답 타입과 쿼리 파라미터 매핑이 함께 변경되었습니다.
- 검색 요약 영역은 supporting text 없이 headline만 사용하도록 정리했습니다.

## 📷 Screenshot
<img width="434" height="898" alt="image" src="https://github.com/user-attachments/assets/353cbfca-b9b4-41a1-a55f-6f52ece1b0a7" />

<img width="441" height="906" alt="image" src="https://github.com/user-attachments/assets/3b9aff66-4b92-4cfc-a34e-416225599cfa" />


## 🔔 ETC
