### PR TITLE
🔧 Refactor(web) : #479 상품/포폴 상세 좋아요 수정

### DIFF
--- a/apps/web/src/app/portfolio/[id]/_section/PortfolioSection.tsx
+++ b/apps/web/src/app/portfolio/[id]/_section/PortfolioSection.tsx
@@ -3,6 +3,7 @@
 import { TagChip, ImageCarousel, LikeButton } from '@snappin/design-system';
 import { MoodCode } from '@snappin/shared/types';
 import { useWishPortfolioLike } from '@/ui/frame/apis';
+import { useLikeButton } from '@/ui/frame/hooks/useLike';
 
 type PortfolioSectionProps = {
   id: number;
@@ -25,11 +26,13 @@ export default function PortfolioSection({
   moods,
   isLogIn,
 }: PortfolioSectionProps) {
-  const { mutate } = useWishPortfolioLike({ id, isLogIn });
-
-  const handleLike = () => {
-    mutate(id);
-  };
+  const { mutate: wishPortfolio} = useWishPortfolioLike({ id, isLogIn });
+  const { liked, handleLike, currentLikeCount } = useLikeButton({
+    id,
+    isLiked,
+    likeCount,
+    mutate: wishPortfolio,
+  });
 
   const portfolioImages = images.map((image) => ({
     src: image,
@@ -49,8 +52,8 @@ export default function PortfolioSection({
           </div>
           {/* 좋아요 */}
           <div className='flex items-start'>
-            <LikeButton isLiked={isLiked} handleClick={handleLike} className='h-[2rem]' />
-            <span className='font-16-rg text-black-8'>{likeCount}</span>
+            <LikeButton isLiked={liked} handleClick={handleLike} className='h-[2rem]' />
+            <span className='font-16-rg text-black-8'>{currentLikeCount}</span>
           </div>
         </div>
         {/* 무드 */}

--- a/apps/web/src/app/product/[id]/_section/ProductMainSection.tsx
+++ b/apps/web/src/app/product/[id]/_section/ProductMainSection.tsx
@@ -5,6 +5,7 @@ import { formatPrice } from '@snappin/shared/lib';
 import { IconStar } from '@snappin/design-system/assets';
 import { ImageCarousel, LikeButton, TagChip } from '@snappin/design-system';
 import { useWishProductLike } from '@/ui/frame/apis';
+import { useLikeButton } from '@/ui/frame/hooks/useLike';
 
 type ProductMainSectionProps = {
   id: number;
@@ -31,13 +32,15 @@ export default function ProductMainSection({
   moods,
   isLogIn,
 }: ProductMainSectionProps) {
-  const { mutateAsync } = useWishProductLike({ id, isLogIn });
+  const { mutate: wishProduct} = useWishProductLike({ id, isLogIn });
+  const { liked, handleLike, currentLikeCount } = useLikeButton({
+    id,
+    isLiked,
+    likeCount,
+    mutate: wishProduct,
+  });
 
   const productImages = images.map((image) => ({ src: image, alt: title }));
-
-  const handleLike = async () => {
-    await mutateAsync(id);
-  };
 
   return (
     <section className='bg-black-1'>
@@ -49,8 +52,8 @@ export default function ProductMainSection({
           <div className='flex justify-between'>
             <h1 className='font-16-md text-black-10'>{title}</h1>
             <div className='flex h-[2.4rem] items-start'>
-              <LikeButton isLiked={isLiked} handleClick={handleLike} className='h-[2rem]' />
-              <span className='font-16-rg text-black-8'>{likeCount}</span>
+              <LikeButton isLiked={liked} handleClick={handleLike} className='h-[2rem]' />
+              <span className='font-16-rg text-black-8'>{currentLikeCount}</span>
             </div>
           </div>
           <span className='title-20-md text-black-10'>{formatPrice(price)}원~</span>


### PR DESCRIPTION
## 📌 Related Issues

<!-- 관련 이슈를 작성해주세요 -->

- close #479

## 🗯️ 체크 리스트

- [x] PR 제목을 규칙에 맞게 작성했나요?  
       EX: 🎀 Feat (design-system) : #이슈번호 PR 내용
- [x] 빌드가 성공했나요? (`pnpm build`)

## 🛠️ Tasks

<!-- 작업한 내용을 작성해주세요 -->


기존 : 로그인 여부 분기 + useWishPortfolio/ProductLike 훅 사용 -> 비로그인 시 좋아요 api 요청 안 보내고 바로 토스트 띄움

그러나 이후 로그인 여부 분기를 제거하는 과정에서 훅은 그대로 사용하여 `비로그인 시 좋아요 버튼 클릭 -> api 호출 -> 낙관적 업데이트로 좋아요 버튼 채워짐 -> api 요청 실패 -> 좋아요 버튼 비워짐` 즉 좋아요 버튼이 깜빡거리는 현상 발생했습니다.

따라서 useWishPortfolio/ProductLike 훅 대신 로그인 여부 분기 로직을 내장하고 있는 useLike 훅을 사용하도록 변경했습니다.

## 👀 PR Point (To Reviewer)

## 📷 Screenshot

<!-- 작업 결과물에 관련된 사진이나 영상 등을 첨부해주세요 -->

### BEFORE

https://github.com/user-attachments/assets/c05ee598-8ca4-4f20-9934-d35fc6d0388c

### AFTER

https://github.com/user-attachments/assets/79ad678f-c3d0-426f-820d-2148cb1cfb86

## 🔔 ETC

<!-- 기타 참고 사항을 작성해주세요 -->
